### PR TITLE
Lyrics font color bug fixes

### DIFF
--- a/src/main/java/com/github/nianna/karedi/Settings.java
+++ b/src/main/java/com/github/nianna/karedi/Settings.java
@@ -9,6 +9,7 @@ import javafx.scene.paint.Color;
 public final class Settings {
 	private static final String LOCALE_LANGUAGE_KEY = "ui_locale_language";
 	private static final String LOCALE_COUNTRY_KEY = "ui_locale_country";
+	private static final String DISPLAY_NOTENODE_UNDERBAR_KEY = "ui_display_notenode_underbar";
 
 	private static Preferences prefs = Preferences.userNodeForPackage(Settings.class);
 
@@ -66,6 +67,14 @@ public final class Settings {
 			prefs.remove(LOCALE_LANGUAGE_KEY);
 			prefs.remove(LOCALE_COUNTRY_KEY);
 		}
+	}
+
+	public static void setDisplayNoteNodeUnderBarEnabled(boolean enabled) {
+		prefs.putBoolean(DISPLAY_NOTENODE_UNDERBAR_KEY, enabled);
+	}
+
+	public static boolean isDisplayNoteNodeUnderBarEnabled() {
+		return prefs.getBoolean(DISPLAY_NOTENODE_UNDERBAR_KEY, true);
 	}
 
 }

--- a/src/main/java/com/github/nianna/karedi/context/AppContext.java
+++ b/src/main/java/com/github/nianna/karedi/context/AppContext.java
@@ -2249,8 +2249,10 @@ public class AppContext {
 		@Override
 		protected void onAction(ActionEvent event) {
 			PreferencesDialog dialog = new PreferencesDialog();
-			dialog.showAndWait().filter(locale -> locale != I18N.getCurrentLocale())
-					.ifPresent(Settings::setLocale);
+			dialog.showAndWait().ifPresent(result -> {
+				Settings.setLocale(result.getSelectedLocale());
+				Settings.setDisplayNoteNodeUnderBarEnabled(result.isDisplayNoteNodeUnderBarEnabled());
+			});
 		}
 	}
 

--- a/src/main/java/com/github/nianna/karedi/dialog/PreferencesDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/PreferencesDialog.java
@@ -1,37 +1,50 @@
 package main.java.com.github.nianna.karedi.dialog;
 
-import java.util.Locale;
-
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ButtonType;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.Dialog;
 import javafx.util.StringConverter;
 import main.java.com.github.nianna.karedi.I18N;
+import main.java.com.github.nianna.karedi.Settings;
 
-public class PreferencesDialog extends Dialog<Locale> {
+import java.util.Locale;
+
+public class PreferencesDialog extends Dialog<PreferencesResult> {
 
 	@FXML
 	private ChoiceBox<Locale> languageSelect;
 
+	@FXML
+	private CheckBox displayNoteNodeUnderBarEnabledCheckBox;
+
 	public PreferencesDialog() {
 		DialogUtils.loadPane(this, getClass().getResource("/fxml/PreferencesLayout.fxml"));
 		setTitle(I18N.get("dialog.preferences.title"));
-		setAvailableLocales();
+		initGeneralTab();
+		initDisplayTab();
 		getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
 
 		setResultConverter(type -> {
 			if (type == ButtonType.OK) {
-				return languageSelect.getSelectionModel().getSelectedItem();
+				return new PreferencesResult(
+						languageSelect.getSelectionModel().getSelectedItem(),
+						displayNoteNodeUnderBarEnabledCheckBox.isSelected()
+				);
 			}
 			return null;
 		});
 
 	}
 
-	private void setAvailableLocales() {
+	private void initDisplayTab() {
+		displayNoteNodeUnderBarEnabledCheckBox.setSelected(Settings.isDisplayNoteNodeUnderBarEnabled());
+	}
+
+	private void initGeneralTab() {
 		ObservableList<Locale> locales = FXCollections
 				.observableArrayList(I18N.getSupportedLocales());
 		languageSelect.setItems(locales);

--- a/src/main/java/com/github/nianna/karedi/dialog/PreferencesResult.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/PreferencesResult.java
@@ -1,0 +1,23 @@
+package main.java.com.github.nianna.karedi.dialog;
+
+import java.util.Locale;
+
+public class PreferencesResult {
+
+    private final Locale selectedLocale;
+
+    private final boolean displayNoteNodeUnderBarEnabled;
+
+    public PreferencesResult(Locale selectedLocale, boolean displayNoteNodeUnderBarEnabled) {
+        this.selectedLocale = selectedLocale;
+        this.displayNoteNodeUnderBarEnabled = displayNoteNodeUnderBarEnabled;
+    }
+
+    public Locale getSelectedLocale() {
+        return selectedLocale;
+    }
+
+    public boolean isDisplayNoteNodeUnderBarEnabled() {
+        return displayNoteNodeUnderBarEnabled;
+    }
+}

--- a/src/main/java/com/github/nianna/karedi/display/NoteNodeDisplayer.java
+++ b/src/main/java/com/github/nianna/karedi/display/NoteNodeDisplayer.java
@@ -21,6 +21,7 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
 import javafx.scene.text.Text;
+import main.java.com.github.nianna.karedi.Settings;
 import main.java.com.github.nianna.karedi.song.Note.Type;
 
 public class NoteNodeDisplayer extends Pane {
@@ -78,6 +79,7 @@ public class NoteNodeDisplayer extends Pane {
 		underBar.add(tone, 0, 0);
 		underBar.add(length, 1, 0);
 		underBar.setHgap(5);
+		underBar.setVisible(Settings.isDisplayNoteNodeUnderBarEnabled());
 		GridPane.setHgrow(length, Priority.ALWAYS);
 		GridPane.setHalignment(length, HPos.RIGHT);
 

--- a/src/main/java/com/github/nianna/karedi/display/NoteNodeDisplayer.java
+++ b/src/main/java/com/github/nianna/karedi/display/NoteNodeDisplayer.java
@@ -19,6 +19,7 @@ import javafx.scene.paint.LinearGradient;
 import javafx.scene.paint.Stop;
 import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Font;
+import javafx.scene.text.FontPosture;
 import javafx.scene.text.FontWeight;
 import javafx.scene.text.Text;
 import main.java.com.github.nianna.karedi.Settings;
@@ -32,9 +33,6 @@ public class NoteNodeDisplayer extends Pane {
 
 	private static final double CUT_BAR_HEIGHT = 5;
 
-	private static final String FREESTYLE_CLASS = "freestyle";
-	private static final String UNDERLINED_CLASS = "underlined";
-
 	private Rectangle cutBar = new Rectangle();
 	private VBox bar = new VBox();
 	private GridPane underBar = new GridPane();
@@ -45,6 +43,7 @@ public class NoteNodeDisplayer extends Pane {
 
 	private ObjectProperty<Color> color = new SimpleObjectProperty<>(DEFAULT_COLOR);
 	private ObjectProperty<Color> fontColor = new SimpleObjectProperty<>(DEFAULT_FONT_COLOR);
+	private FontPosture fontPosture = FontPosture.REGULAR;
 
 	private DropShadow borderGlow = new DropShadow();
 	private SepiaTone selectedEffect = new SepiaTone();
@@ -68,14 +67,14 @@ public class NoteNodeDisplayer extends Pane {
 
 		repaintBar();
 
-		lyrics.getStyleClass().add("note-lyrics");
 		length.getStyleClass().add("under-note-lyrics");
 		tone.getStyleClass().add("under-note-lyrics");
 
-		bar.getChildren().addAll(lyrics);
-		bar.setAlignment(Pos.CENTER);
+		StackPane barWithLyricsWrapper = new StackPane();
+		barWithLyricsWrapper.getChildren().addAll(bar, lyrics);
+		barWithLyricsWrapper.setAlignment(Pos.CENTER);
 
-		noteBox.getChildren().addAll(bar, underBar);
+		noteBox.getChildren().addAll(barWithLyricsWrapper, underBar);
 		underBar.add(tone, 0, 0);
 		underBar.add(length, 1, 0);
 		underBar.setHgap(5);
@@ -116,7 +115,7 @@ public class NoteNodeDisplayer extends Pane {
 	}
 
 	private void onBarHeightChanged(Observable obs, Number oldValue, Number newValue) {
-		lyrics.setFont(Font.font(lyrics.getFont().getFamily(), FontWeight.BOLD, newValue.intValue() * 0.5));
+		repaintLyrics();
 	}
 
 	private void onBarHeightInvalidated(Observable obs) {
@@ -161,6 +160,18 @@ public class NoteNodeDisplayer extends Pane {
 		bar.setBackground(background);
 		lastRefreshHeight = getBarHeight();
 		lastRefreshWidth = getBarWidth();
+	}
+
+	private void repaintLyrics() {
+		lyrics.setFont(
+				Font.font(
+						lyrics.getFont().getFamily(),
+						FontWeight.BOLD,
+						fontPosture,
+						bar.getHeight() * 0.5
+				)
+		);
+		lyrics.setFill(fontColor.get());
 	}
 
 	ObjectProperty<Color> colorProperty() {
@@ -270,22 +281,23 @@ public class NoteNodeDisplayer extends Pane {
 
 	void breaksLine(boolean breaksLine) {
 		if (breaksLine) {
-			lyrics.getStyleClass().add(UNDERLINED_CLASS);
+			lyrics.setUnderline(true);
 		} else {
-			lyrics.getStyleClass().remove(UNDERLINED_CLASS);
+			lyrics.setUnderline(false);
 		}
 	}
 
 	public void updateType(Type oldType, Type newType) {
 		if (oldType != newType) {
-			resetTypeEffect(oldType);
+			resetTypeEffect();
 			setTypeEffect(newType);
 			repaintBar();
+			repaintLyrics();
 		}
 	}
 
-	private void resetTypeEffect(Type type) {
-		lyrics.getStyleClass().remove(FREESTYLE_CLASS);
+	private void resetTypeEffect() {
+		fontPosture = FontPosture.REGULAR;
 		if (isSelected) {
 			bar.setEffect(selectedEffect);
 		} else {
@@ -325,7 +337,7 @@ public class NoteNodeDisplayer extends Pane {
 
 	private void addFreestyleEffect() {
 		borderGlow.setColor(Color.GRAY.darker());
-		lyrics.getStyleClass().add(FREESTYLE_CLASS);
+		fontPosture = FontPosture.ITALIC;
 		borderGlow.setInput(bar.getEffect());
 		bar.setEffect(borderGlow);
 		isStyled = true;

--- a/src/main/resources/com/github/nianna/karedi/Karedi.css
+++ b/src/main/resources/com/github/nianna/karedi/Karedi.css
@@ -59,21 +59,8 @@
 	-fx-alignment: CENTER_LEFT;
 }
 
-.underlined {
-	-fx-underline: true;
-}
-
-.note-lyrics {
-	-fx-font-weight: bold;
-	-fx-fill: white;
-}
-
 .under-note-lyrics {
 	-fx-font-weight: bold;
-}
-
-.freestyle {
-	-fx-font-style: italic;
 }
 
 .medley-area {

--- a/src/main/resources/com/github/nianna/karedi/fxml/PreferencesLayout.fxml
+++ b/src/main/resources/com/github/nianna/karedi/fxml/PreferencesLayout.fxml
@@ -14,6 +14,7 @@
 
 <!-- <?import org.controlsfx.glyphfont.*?> -->
 
+<?import javafx.scene.control.CheckBox?>
 <fx:root type="javafx.scene.control.DialogPane" xmlns="http://javafx.com/javafx/8.0.60" xmlns:fx="http://javafx.com/fxml/1">
 	<content>
 		<TabPane>
@@ -51,6 +52,39 @@
                   </VBox>
 					</content>
 				</Tab>
+            <Tab text="%dialog.preferences.display">
+               <content>
+                  <VBox>
+                     <children>
+                        <GridPane fx:id="gridPane11" hgap="10.0" vgap="10.0">
+                           <columnConstraints>
+                              <ColumnConstraints hgrow="SOMETIMES" />
+                              <ColumnConstraints hgrow="SOMETIMES" prefWidth="200.0" />
+                              <ColumnConstraints />
+                           </columnConstraints>
+                           <children>
+                              <Label text="%dialog.preferences.display.notenode_underbar_enabled.label" GridPane.rowIndex="1" />
+                              <CheckBox fx:id="displayNoteNodeUnderBarEnabledCheckBox" prefWidth="200.0" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                           </children>
+                           <rowConstraints>
+                              <RowConstraints />
+                              <RowConstraints />
+                              <RowConstraints />
+                           </rowConstraints>
+                        </GridPane>
+                        <Separator prefWidth="200.0">
+                           <padding>
+                              <Insets bottom="10.0" top="10.0" />
+                           </padding>
+                        </Separator>
+                        <Label text="%dialog.preferences.song_reload_required" />
+                     </children>
+                     <padding>
+                        <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                     </padding>
+                  </VBox>
+               </content>
+            </Tab>
 			</tabs>
 		</TabPane>
 	</content>

--- a/src/main/resources/com/github/nianna/karedi/messages_en_GB.properties
+++ b/src/main/resources/com/github/nianna/karedi/messages_en_GB.properties
@@ -196,10 +196,13 @@ dialog.tag.value=Value:
 
 dialog.preferences.title=Preferences
 dialog.preferences.general=General
+dialog.preferences.display=Display
 dialog.preferences.languages.label=Language:*
 dialog.preferences.language.en_GB=British English
 dialog.preferences.language.pl_PL=Polish
 dialog.preferences.restart_required=* Restart application for this change to take effect
+dialog.preferences.song_reload_required=* Reload song for this change to take effect
+dialog.preferences.display.notenode_underbar_enabled.label=Show tone and length under notes in editor:*
 
 dialog.track_export.title=Choose tracks to export
 dialog.track_export.header=Please choose {0, number, integer}:

--- a/src/main/resources/com/github/nianna/karedi/messages_pl_PL.properties
+++ b/src/main/resources/com/github/nianna/karedi/messages_pl_PL.properties
@@ -51,7 +51,7 @@ ui.menu.mark_as=Oznacz jako
 ui.menu.mark_as.golden=Z\u0142ote
 ui.menu.mark_as.freestyle=Freestyle
 ui.menu.mark_as.rap=Rap
-ui.menu.show_preferences=Preferencje...
+ui.menu.show_preferences=Ustawienia...
 
 ui.menu.lyrics=_Tekst
 ui.menu.lyrics.edit=Edytuj
@@ -196,12 +196,15 @@ dialog.tag.key_required=Klucz jest wymagany
 dialog.tag.key=Klucz:
 dialog.tag.value=Warto\u015B\u0107:
 
-dialog.preferences.title=Preferencje
+dialog.preferences.title=Ustawienia
 dialog.preferences.general=Ogólne
+dialog.preferences.display=Wy\u015Bwietlanie
 dialog.preferences.languages.label=J\u0119zyk:*
 dialog.preferences.language.en_GB=angielski
 dialog.preferences.language.pl_PL=polski
-dialog.preferences.restart_required=* Zrestartuj aplikacj\u0119, aby zmiana odnios\u0142a sukces
+dialog.preferences.restart_required=* Zrestartuj aplikacj\u0119, aby zobaczy\u0107 efekt
+dialog.preferences.song_reload_required=* Prze\u0142aduj piosenk\u0119, aby zobaczy\u0107 efekt
+dialog.preferences.display.notenode_underbar_enabled.label=Pokazuj d\u0142ugo\u015B\u0107 i wysoko\u015B\u0107 pod nutami w edytorze:*
 
 dialog.track_export.title=Wybierz \u015Bcie\u017Cki
 dialog.track_export.header=Prosz\u0119 wybierz {0, number, integer}:


### PR DESCRIPTION
Adding option in Settings to disable tone and length info displayed under notes in editor as it may be too overwhelming when working with multiple tracks.

Fixed various issues caused by moving lyrics onto notes and using mixed approach to font styling (via code & css):
 * rap notes lyrics were blurred and unreadable
 * immediately after loading freestyle notes text was not in italics
 * changing color removed italics on freestyle notes
 * freestyling notes removed font color.