### PR TITLE
Fix/add missing export and opens module declarations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,21 +288,34 @@
 						<javaOption>--add-exports=javafx.base/com.sun.javafx.event=org.controlsfx.controls</javaOption>
 					</javaOptions>
 					<module>karedi/${project.mainClass}</module>
-					<winShortcut>true</winShortcut>
-					<winDirChooser>true</winDirChooser>
-					<winMenu>true</winMenu>
-					<winPerUserInstall>true</winPerUserInstall>
-					<winUpgradeUuid>643965f2-2ce8-4bd5-87de-e3074e25d589</winUpgradeUuid>
-<!--					use for Windows *.exe images -->
-					<icon>src/main/resources/icon/icon.ico</icon>
-<!--					use for Linux *.deb images -->
-<!--					<icon>src/main/resources/icon/icon.png</icon>-->
-					<linuxShortcut>true</linuxShortcut>
-					<linuxAppCategory>Audio;AudioVideo</linuxAppCategory>
-<!--					use for macOS *.dmg images -->
-<!--					<icon>src/main/resources/icon/icon.icns</icon>-->
 					<verbose>true</verbose>
 				</configuration>
+				<executions>
+					<execution>
+						<id>win</id>
+						<configuration>
+							<icon>src/main/resources/icon/icon.ico</icon>
+							<winShortcut>true</winShortcut>
+							<winDirChooser>true</winDirChooser>
+							<winMenu>true</winMenu>
+							<winPerUserInstall>true</winPerUserInstall>
+							<winUpgradeUuid>643965f2-2ce8-4bd5-87de-e3074e25d589</winUpgradeUuid>
+						</configuration>
+					</execution>
+					<execution>
+						<id>mac</id>
+						<configuration>
+							<icon>icons/icons.icns</icon>
+						</configuration>
+					</execution>
+					<execution>
+						<id>linux</id>
+						<configuration>
+							<linuxShortcut>true</linuxShortcut>
+							<linuxAppCategory>Audio;AudioVideo</linuxAppCategory>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
 				<version>1.6.0</version>
 				<configuration>
 					<name>${project.artifactId}</name>
-					<appVersion>1.3.0.1</appVersion>
+					<appVersion>${project.version}</appVersion>
 					<vendor>${project.vendor}</vendor>
 					<destination>${project.dist.outputDirectory}</destination>
 					<modulePaths>
@@ -284,6 +284,9 @@
 						<modulePath>${settings.localRepository}\org\controlsfx\controlsfx\${controlsfx.version}</modulePath>
 						<modulePath>${project.jars.outputDirectory}</modulePath>
 					</modulePaths>
+					<javaOptions>
+						<javaOption>--add-exports=javafx.base/com.sun.javafx.event=org.controlsfx.controls</javaOption>
+					</javaOptions>
 					<module>karedi/${project.mainClass}</module>
 					<winShortcut>true</winShortcut>
 					<winDirChooser>true</winDirChooser>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -14,6 +14,7 @@ module karedi {
 
     opens com.github.nianna.karedi to javafx.graphics;
     opens com.github.nianna.karedi.controller to javafx.fxml;
+    opens com.github.nianna.karedi.dialog to javafx.fxml;
     opens com.github.nianna.karedi.display to javafx.fxml;
     opens com.github.nianna.karedi.control to javafx.fxml;
 }


### PR DESCRIPTION
New Song wizard does not work because of 2 reasons:
- missing opens declaration
- ControlsFX library uses internal packages of javafx.base - additional add-exports option to JVM is necessary to make it work