### PR TITLE
Play audio to the end while tapping notes while showing 5 secs area

### DIFF
--- a/src/main/java/com/github/nianna/karedi/context/BeatRangeContext.java
+++ b/src/main/java/com/github/nianna/karedi/context/BeatRangeContext.java
@@ -54,6 +54,10 @@ public class BeatRangeContext {
         return beatMillisConverter.beatToMillis(beat);
     }
 
+    public int millisToBeat(int millis) {
+        return beatMillisConverter.millisToBeat(millis);
+    }
+
     private void onBeatMillisConverterInvalidated() {
         if (isNull(activeSongProperty.get())) {
             beatMillisConverter.setBpm(Song.DEFAULT_BPM);

--- a/src/main/java/com/github/nianna/karedi/controller/EditorController.java
+++ b/src/main/java/com/github/nianna/karedi/controller/EditorController.java
@@ -552,7 +552,7 @@ public class EditorController implements Controller {
             updateInterval = getBeatDuration() / 2;
             tapping = true;
             activeSongContext.activeTrackProperty().addListener(activeTrackListener);
-            actionContext.execute(KarediActions.PLAY_VISIBLE_AUDIO);
+            actionContext.execute(KarediActions.PLAY_TO_THE_END_AUDIO);
             audioContext.playerStatusProperty().addListener(playerStatusListener);
             hBox.setOnKeyPressed(this::onKeyPressedWhileTapping);
             hBox.setOnKeyReleased(this::onKeyReleasedWhileTapping);

--- a/src/main/java/com/github/nianna/karedi/controller/EditorController.java
+++ b/src/main/java/com/github/nianna/karedi/controller/EditorController.java
@@ -513,6 +513,9 @@ public class EditorController implements Controller {
     }
 
     private class TapNotesAction extends KarediAction {
+
+        private static final int VISIBLE_TIME_IN_MS_FOR_TAPPING = 5_000;
+
         private InvalidationListener playerStatusListener;
         private InvalidationListener activeTrackListener;
         private EventHandler<? super KeyEvent> onKeyPressed;
@@ -547,7 +550,7 @@ public class EditorController implements Controller {
             selectionContext.getSelection().clear();
             onKeyPressed = hBox.getOnKeyPressed();
             onKeyReleased = hBox.getOnKeyReleased();
-            visibleAreaContext.assertAllNeededTonesVisible();
+            adjustVisibleAreaForTapping();
             tone = getToneForTappedNote();
             updateInterval = getBeatDuration() / 2;
             tapping = true;
@@ -556,6 +559,16 @@ public class EditorController implements Controller {
             audioContext.playerStatusProperty().addListener(playerStatusListener);
             hBox.setOnKeyPressed(this::onKeyPressedWhileTapping);
             hBox.setOnKeyReleased(this::onKeyReleasedWhileTapping);
+        }
+
+        private void adjustVisibleAreaForTapping() {
+            audioContext.setMarkerBeat(visibleAreaContext.getLowerXBound());
+            int beats = beatRangeContext.millisToBeat(VISIBLE_TIME_IN_MS_FOR_TAPPING);
+            visibleAreaContext.setVisibleAreaXBounds(
+                    visibleAreaContext.getLowerXBound(),
+                    visibleAreaContext.getLowerXBound() + beats
+            );
+            visibleAreaContext.assertAllNeededTonesVisible();
         }
 
         private void reset() {


### PR DESCRIPTION
Previously while tapping only the visible area was played.

After change the whole song from current place to the end of the song is played with 5 seconds worth of beats visible in the editor.