### PR TITLE
Feat/add automatic syllabification for japanese

### DIFF
--- a/src/main/java/com/github/nianna/karedi/context/AppContext.java
+++ b/src/main/java/com/github/nianna/karedi/context/AppContext.java
@@ -21,6 +21,8 @@ public class AppContext {
 
 	private final BeatRangeContext beatRangeContext = new BeatRangeContext(activeSongContext);
 
+	private final SyllabizerContext syllabizerContext = new SyllabizerContext(activeSongContext);
+
 	private final AudioContext audioContext = new AudioContext(beatRangeContext, activeSongContext);
 
 	private final VisibleAreaContext visibleAreaContext = new VisibleAreaContext(
@@ -66,6 +68,10 @@ public class AppContext {
 
 	public BeatRangeContext getBeatRangeContext() {
 		return beatRangeContext;
+	}
+
+	public SyllabizerContext getSyllabizerContext() {
+		return syllabizerContext;
 	}
 
 	public AudioContext getAudioContext() {

--- a/src/main/java/com/github/nianna/karedi/context/SyllabizerContext.java
+++ b/src/main/java/com/github/nianna/karedi/context/SyllabizerContext.java
@@ -1,0 +1,32 @@
+package com.github.nianna.karedi.context;
+
+import com.github.nianna.karedi.song.Song;
+import com.github.nianna.karedi.song.tag.TagKey;
+import com.github.nianna.karedi.syllabizer.Syllabizer;
+import com.github.nianna.karedi.syllabizer.SyllabizerFactory;
+import com.github.nianna.karedi.util.Language;
+import javafx.beans.property.ReadOnlyObjectProperty;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class SyllabizerContext {
+
+    private static final Map<Language, Syllabizer> SYLLABIZERS = new HashMap<>();
+
+    private final ReadOnlyObjectProperty<Song> activeSongProperty;
+
+    SyllabizerContext(ActiveSongContext activeSongContext) {
+        this.activeSongProperty = activeSongContext.activeSongProperty();
+        SyllabizerFactory.supportedLanguages()
+                .forEach(language -> SYLLABIZERS.put(language, SyllabizerFactory.createFor(language)));
+    }
+
+    public Optional<Syllabizer> findSyllabizer() {
+        return Optional.of(activeSongProperty.get())
+                .flatMap(song -> song.getTagValue(TagKey.LANGUAGE))
+                .flatMap(Language::parse)
+                .map(SYLLABIZERS::get);
+    }
+}

--- a/src/main/java/com/github/nianna/karedi/syllabizer/JapaneseSyllabizer.java
+++ b/src/main/java/com/github/nianna/karedi/syllabizer/JapaneseSyllabizer.java
@@ -1,0 +1,79 @@
+package com.github.nianna.karedi.syllabizer;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+class JapaneseSyllabizer implements Syllabizer {
+
+    private static final Set<Character> CONSONANTS = Set.of(
+            'b', 'c', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'p', 'q', 'r', 's', 't', 'v', 'w', 'x', 'y', 'z'
+    );
+
+    private static final Set<Character> VOWELS = Set.of('a', 'i', 'u', 'e', 'o');
+
+    /**
+     * Splits multiline text written in romaji into list of syllables (more precisely moras).
+     * <p>
+     * Japanese mora must contain one vowel, exceptions are:
+     * <ul>
+     * <li>'n' which is a mora on its own</li>
+     * <li>'~' which represents the prolongation of the preceding vowel in Ultrastar txt format</li>
+     * </ul>
+     * </p>
+     */
+    @Override
+    public List<String> syllabize(String input) {
+        String normalized = input.replaceAll("\\R", " ").stripTrailing();
+        return syllabizeNormalized(normalized);
+    }
+
+    private List<String> syllabizeNormalized(String input) {
+        List<String> results = new LinkedList<>();
+        int nextSyllableStartIndex = 0;
+        boolean canNextSyllableBeFinished = false;
+        char currentChar;
+        Character lastChar = null;
+        for (int i = 0; i < input.length(); i++) {
+            currentChar = input.charAt(i);
+            if (isN(lastChar) && canStartNextSyllable(currentChar)) {
+                results.add(input.substring(nextSyllableStartIndex, i));
+                nextSyllableStartIndex = i;
+                canNextSyllableBeFinished = currentChar == '~';
+            } else {
+                if (isVowel(currentChar) || currentChar == '~') {
+                    if (canNextSyllableBeFinished) {
+                        results.add(input.substring(nextSyllableStartIndex, i));
+                        nextSyllableStartIndex = i;
+                    }
+                    canNextSyllableBeFinished = true;
+                } else {
+                    if (canNextSyllableBeFinished && canStartNextSyllable(currentChar)) {
+                        results.add(input.substring(nextSyllableStartIndex, i));
+                        nextSyllableStartIndex = i;
+                        canNextSyllableBeFinished = false;
+                    }
+                }
+            }
+            lastChar = currentChar;
+        }
+        results.add(input.substring(nextSyllableStartIndex));
+        return results;
+    }
+
+    private boolean isN(Character character) {
+        return character != null && Character.toLowerCase(character) == 'n';
+    }
+
+    private boolean canStartNextSyllable(Character character) {
+        return isConsonant(character) || character == ' ' || character == '-' || character == '~';
+    }
+
+    private boolean isVowel(Character character) {
+        return character != null && VOWELS.contains(Character.toLowerCase(character));
+    }
+
+    private boolean isConsonant(Character character) {
+        return character != null && CONSONANTS.contains(Character.toLowerCase(character));
+    }
+}

--- a/src/main/java/com/github/nianna/karedi/syllabizer/Syllabizer.java
+++ b/src/main/java/com/github/nianna/karedi/syllabizer/Syllabizer.java
@@ -1,0 +1,8 @@
+package com.github.nianna.karedi.syllabizer;
+
+import java.util.List;
+
+public interface Syllabizer {
+
+    List<String> syllabize(String input);
+}

--- a/src/main/java/com/github/nianna/karedi/syllabizer/SyllabizerFactory.java
+++ b/src/main/java/com/github/nianna/karedi/syllabizer/SyllabizerFactory.java
@@ -1,0 +1,26 @@
+package com.github.nianna.karedi.syllabizer;
+
+import com.github.nianna.karedi.util.Language;
+
+import java.util.Set;
+
+import static com.github.nianna.karedi.util.Language.JAPANESE;
+
+public class SyllabizerFactory {
+
+    private SyllabizerFactory() {
+
+    }
+
+    public static Syllabizer createFor(Language language) {
+        if (language == JAPANESE) {
+            return new JapaneseSyllabizer();
+        }
+        return null;
+    }
+
+    public static Set<Language> supportedLanguages() {
+        return Set.of(JAPANESE);
+    }
+
+}

--- a/src/main/java/com/github/nianna/karedi/txt/loader/SongLoader.java
+++ b/src/main/java/com/github/nianna/karedi/txt/loader/SongLoader.java
@@ -11,6 +11,7 @@ import com.github.nianna.karedi.util.MultiplayerTags;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Logger;
 
 class SongLoader {
@@ -39,6 +40,7 @@ class SongLoader {
 				.map(String::strip)
 				.filter(line -> !line.isBlank())
 				.map(this::parseLine)
+				.filter(Objects::nonNull)
 				.forEach(songBuilder::buildPart);
 		Song song = songBuilder.getResult();
 		extractTrackNamesFromTags(song);

--- a/src/main/java/com/github/nianna/karedi/util/KeyCodeCombinations.java
+++ b/src/main/java/com/github/nianna/karedi/util/KeyCodeCombinations.java
@@ -5,11 +5,23 @@ import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
 
 public final class KeyCodeCombinations {
-	public static final KeyCodeCombination CTRL_X = new KeyCodeCombination(KeyCode.X,
-			KeyCombination.SHORTCUT_DOWN);
-	public static final KeyCodeCombination CTRL_V = new KeyCodeCombination(KeyCode.V,
-			KeyCombination.SHORTCUT_DOWN);
 
-	private KeyCodeCombinations() {
-	}
+    public static final KeyCodeCombination CTRL_X = new KeyCodeCombination(
+			KeyCode.X,
+            KeyCombination.SHORTCUT_DOWN
+	);
+
+    public static final KeyCodeCombination CTRL_V = new KeyCodeCombination(
+			KeyCode.V,
+            KeyCombination.SHORTCUT_DOWN
+	);
+
+    public static final KeyCodeCombination CTRL_SHIFT_V = new KeyCodeCombination(
+			KeyCode.V,
+            KeyCombination.SHORTCUT_DOWN,
+			KeyCombination.SHIFT_DOWN
+	);
+
+    private KeyCodeCombinations() {
+    }
 }

--- a/src/main/java/com/github/nianna/karedi/util/Language.java
+++ b/src/main/java/com/github/nianna/karedi/util/Language.java
@@ -1,5 +1,8 @@
 package com.github.nianna.karedi.util;
 
+import java.util.Optional;
+import java.util.stream.Stream;
+
 public enum Language {
 	// List of languages accepted by ultrastar-es.org
 	BASQUE,
@@ -46,6 +49,15 @@ public enum Language {
 	public String toString() {
 		String str = super.toString();
 		return str.charAt(0) + str.substring(1).toLowerCase();
+	}
+
+	public static Optional<Language> parse(String language) {
+		if (language == null) {
+			return Optional.empty();
+		}
+		return Stream.of(values())
+				.filter(value -> value.name().equals(language.toUpperCase()))
+				.findFirst();
 	}
 
 }

--- a/src/main/java/com/github/nianna/karedi/util/Language.java
+++ b/src/main/java/com/github/nianna/karedi/util/Language.java
@@ -56,7 +56,7 @@ public enum Language {
 			return Optional.empty();
 		}
 		return Stream.of(values())
-				.filter(value -> value.name().equals(language.toUpperCase()))
+				.filter(value -> value.toString().equalsIgnoreCase(language))
 				.findFirst();
 	}
 

--- a/src/test/java/com/github/nianna/karedi/syllabizer/JapaneseSyllabizerTest.java
+++ b/src/test/java/com/github/nianna/karedi/syllabizer/JapaneseSyllabizerTest.java
@@ -1,0 +1,99 @@
+package com.github.nianna.karedi.syllabizer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JapaneseSyllabizerTest {
+
+    JapaneseSyllabizer syllabizer = new JapaneseSyllabizer();
+
+    @Test
+    public void shouldPlaceSpaceCharacterAtTheBeginningOfSyllables() {
+        String input = "la lala";
+        List<String> result = syllabizer.syllabize(input);
+        assertEquals(List.of("la", " la", "la"), result);
+    }
+
+    @Test
+    public void shouldTreatVowelsAsSyllables() {
+        String input = "aiueo";
+        List<String> result = syllabizer.syllabize(input);
+        assertEquals(List.of("a", "i", "u", "e", "o"), result);
+    }
+
+    @Test
+    public void shouldIncludeOneVowelPerSyllable() {
+        String input = "Karaage ga suki desu";
+        List<String> result = syllabizer.syllabize(input);
+        assertEquals(List.of("Ka", "ra", "a", "ge", " ga", " su", "ki", " de", "su"), result);
+    }
+
+    @Test
+    public void shouldAcceptDoubleConsonantsInSyllables() {
+        String input = "SAMUKATTA gyoza zetsumei";
+        List<String> result = syllabizer.syllabize(input);
+        assertEquals(List.of("SA", "MU", "KA", "TTA", " gyo", "za", " ze", "tsu", "me", "i"), result);
+    }
+
+    @Test
+    public void shouldTreatLongVowelsAsTwoSyllables() {
+        String input = "kirei deshou";
+        List<String> result = syllabizer.syllabize(input);
+        assertEquals(List.of("ki", "re", "i", " de", "sho", "u"), result);
+    }
+
+    @Test
+    public void shouldTreatLetterNAsASeparateSyllableIfItIsNotFollowedByAVowel() {
+        String input = "Ran no bentou";
+        List<String> result = syllabizer.syllabize(input);
+        assertEquals(List.of("Ra", "n", " no", " be", "n", "to", "u"), result);
+    }
+
+    @Test
+    public void shouldRecognizeNaNiNuNeNoSyllables() {
+        String input = "Nina no neko ga nureta";
+        List<String> result = syllabizer.syllabize(input);
+        assertEquals(List.of("Ni", "na", " no", " ne", "ko", " ga", " nu", "re", "ta"), result);
+    }
+
+    @Test
+    public void shouldPlaceDashAtTheBeginningOfSyllable() {
+        String input = "Nii-san";
+        List<String> result = syllabizer.syllabize(input);
+        assertEquals(List.of("Ni", "i", "-sa", "n"), result);
+    }
+
+    @Test
+    public void shouldPlaceOtherPunctuationCharactersAtTheEndOfSyllables() {
+        String input = "Nani???!?! \"Honmyou: (namae) 'Tesuto'\");";
+        List<String> result = syllabizer.syllabize(input);
+        assertEquals(List.of("Na", "ni???!?!", " \"Ho", "n", "myo", "u:", " (na", "ma", "e)", " 'Te", "su", "to'\");"), result);
+    }
+
+    @Test
+    public void shouldReplaceNewLineCharacterWithSpace() {
+        String input = """
+        Ichi
+        Ni
+        """;
+        List<String> result = syllabizer.syllabize(input);
+        assertEquals(List.of("I", "chi", " Ni"), result);
+    }
+
+    @Test
+    public void shouldTreatNonJapaneseConsonantsLikeJapaneseConsonants() {
+        String input = "quxxo vi";
+        List<String> result = syllabizer.syllabize(input);
+        assertEquals(List.of("qu", "xxo", " vi"), result);
+    }
+
+    @Test
+    public void shouldTreatTildeAsSeparateSyllable() {
+        String input = "Ran~ La~~~! ~? Ha~ppi";
+        List<String> result = syllabizer.syllabize(input);
+        assertEquals(List.of("Ra", "n", "~", " La", "~", "~", "~!", " ~?", " Ha", "~", "ppi"), result);
+    }
+}

--- a/src/test/java/com/github/nianna/karedi/util/LanguageTest.java
+++ b/src/test/java/com/github/nianna/karedi/util/LanguageTest.java
@@ -1,0 +1,31 @@
+package com.github.nianna.karedi.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LanguageTest {
+
+    @Test
+    public void shouldParseEmptyOptionalFromNull() {
+        Optional<Language> result = Language.parse(null);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void shouldParseEmptyOptionalFromInvalidValue() {
+        Optional<Language> result = Language.parse("unknown");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void shouldParseLanguageFromValidValue() {
+        Optional<Language> result = Language.parse("jApaNese");
+        assertTrue(result.isPresent());
+        assertEquals(Language.JAPANESE, result.get());
+    }
+
+}


### PR DESCRIPTION
Added simple algorithm for automatic splitting of Japanese text (romaji) into syllables.
Text is syllabized when pasting using ctrl + V, not syllabized when using ctrl + shift + V.