### PR TITLE
feat(history): Add workaround for disappearing history entries

### DIFF
--- a/src/main/java/com/github/nianna/karedi/controller/HistoryListViewSkin.java
+++ b/src/main/java/com/github/nianna/karedi/controller/HistoryListViewSkin.java
@@ -1,0 +1,29 @@
+package com.github.nianna.karedi.controller;
+
+import com.github.nianna.karedi.command.Command;
+import javafx.scene.control.ListView;
+import javafx.scene.control.skin.ListViewSkin;
+
+/**
+ * This class is a workaround for bug in ListView/VirtualFlow.
+ *
+ * If the ListView contains more items than the list height's in pixels then automatic scroll to the trailing items
+ * causes only one item to be rendered in the view. Fortunately manual scrolling fixes this issue.
+ */
+public class HistoryListViewSkin extends ListViewSkin<Command> {
+
+    private static final double FAKE_SCROLL_DELTA = 100;
+
+    public HistoryListViewSkin(ListView<Command> listView) {
+        super(listView);
+    }
+
+    public void fixDisplay() {
+        super.getVirtualFlow().scrollPixels(-FAKE_SCROLL_DELTA);
+        super.getVirtualFlow().scrollPixels(FAKE_SCROLL_DELTA);
+    }
+
+    public int getFlowCellSize() {
+        return super.getVirtualFlow().getCellCount();
+    }
+}


### PR DESCRIPTION
There seems to be a bug in JavaFX libraries.

When ListView has more items than its heigh in px then scrollTo method totally breaks the display - even if e.g. 6 items would fit in the panel, only the last one is displayed.
Manual scroll works fine and fixes the issue, hence such workaround.