### PR TITLE
feat(history): Hardcode condition when workaround is necessary

### DIFF
--- a/src/main/java/com/github/nianna/karedi/controller/HistoryController.java
+++ b/src/main/java/com/github/nianna/karedi/controller/HistoryController.java
@@ -79,13 +79,9 @@ public class HistoryController implements Controller {
     private void onActiveCommandChanged(Observable obs, Command oldCmd, Command newCmd) {
         list.getSelectionModel().select(newCmd);
         if (!changedByUser) {
-            // Workaround for disappearing leading entries in the UI
-            int cellSizePreScroll = historyListViewSkin.getFlowCellSize();
             list.scrollTo(newCmd);
-            int cellSizePostScroll = historyListViewSkin.getFlowCellSize();
-            if (cellSizePreScroll != cellSizePostScroll) {
-                historyListViewSkin.fixDisplay();
-            }
+            // Workaround for disappearing leading entries in the UI
+            historyListViewSkin.fixDisplay();
         }
     }
 

--- a/src/main/java/com/github/nianna/karedi/controller/HistoryListViewSkin.java
+++ b/src/main/java/com/github/nianna/karedi/controller/HistoryListViewSkin.java
@@ -19,11 +19,9 @@ public class HistoryListViewSkin extends ListViewSkin<Command> {
     }
 
     public void fixDisplay() {
-        super.getVirtualFlow().scrollPixels(-FAKE_SCROLL_DELTA);
-        super.getVirtualFlow().scrollPixels(FAKE_SCROLL_DELTA);
-    }
-
-    public int getFlowCellSize() {
-        return super.getVirtualFlow().getCellCount();
+        if (super.getVirtualFlow().getCellCount() >= (int) getVirtualFlow().getHeight()) {
+            super.getVirtualFlow().scrollPixels(-FAKE_SCROLL_DELTA);
+            super.getVirtualFlow().scrollPixels(FAKE_SCROLL_DELTA);
+        }
     }
 }


### PR DESCRIPTION
Previous condition worked for adding items, but not on quick Undo/Redo invocations.