### PR TITLE
Reset midi sequencer on song reload

### DIFF
--- a/src/main/java/com/github/nianna/karedi/context/actions/ReloadSongAction.java
+++ b/src/main/java/com/github/nianna/karedi/context/actions/ReloadSongAction.java
@@ -2,6 +2,7 @@ package com.github.nianna.karedi.context.actions;
 
 
 import com.github.nianna.karedi.KarediApp;
+import com.github.nianna.karedi.action.KarediActions;
 import com.github.nianna.karedi.context.AppContext;
 import javafx.event.ActionEvent;
 
@@ -18,6 +19,7 @@ class ReloadSongAction extends ContextfulKarediAction {
     protected void onAction(ActionEvent event) {
         if (KarediApp.getInstance().saveChangesIfUserWantsTo()) {
             backupTrackAndLine();
+            executeAction(KarediActions.RESET_SEQUENCER);
             txtContext.loadSongFile(txtContext.getActiveFile(), false);
 
             if (activeSongContext.getSong() != null) {


### PR DESCRIPTION
Sometimes midi sequencer starts lagging, which affects midi and midi+audio playback. The lag can be removed only by "reseting" the sequencer. The cause of this bug is unknown but it seems to be unrelated to the Karedi itself.

There is already a manual workaround implemented - clicking Help -> Debug -> Reset Piano will fix the issue, but not everyone knows about this option. The first thing most people will try is saving and reloading the song, hence it makes to automatically activate the workaround just in case on song reload.