### PR TITLE
Merge META-INF/services in fat jar to support both OGG and AAC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,9 @@
 						</manifest>
 					</archive>
 					<outputDirectory>${project.dist.outputDirectory}</outputDirectory>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
+					<descriptors>
+						<descriptor>src/main/resources/assembly.xml</descriptor>
+					</descriptors>
 					<appendAssemblyId>false</appendAssemblyId>
 				</configuration>
 				<executions>

--- a/src/main/resources/assembly.xml
+++ b/src/main/resources/assembly.xml
@@ -1,0 +1,22 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <id>jar-with-dependencies</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+    <containerDescriptorHandlers>
+        <containerDescriptorHandler>
+            <handlerName>metaInf-services</handlerName>
+        </containerDescriptorHandler>
+    </containerDescriptorHandlers>
+</assembly>


### PR DESCRIPTION
By default _jar-with-dependencies_ descriptor of _maven-assembly-plugin_ puts one arbirtarily chosen file in the fat jar if there are multiple files with the same name. As a result Java sound api service providers from only one library are defined in the fat jar (so either OGG or AAC files are supported).

By using built-in _metaInf-services_ container descriptor handler, the plugin merges contents of services files and therefore is listing providers from all libraries.
Closes #39