### PR TITLE
Adjust new song wizard to multiple audio formats

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -481,6 +481,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.openjfx</groupId>
 			<artifactId>javafx-controls</artifactId>
 			<version>${javafx.version}</version>

--- a/src/main/java/com/github/nianna/karedi/KarediApp.java
+++ b/src/main/java/com/github/nianna/karedi/KarediApp.java
@@ -2,6 +2,7 @@ package com.github.nianna.karedi;
 
 import com.github.nianna.karedi.action.KarediActions;
 import com.github.nianna.karedi.context.AppContext;
+import com.github.nianna.karedi.context.AudioContext;
 import com.github.nianna.karedi.controller.RootController;
 import com.github.nianna.karedi.dialog.SaveChangesAlert;
 import javafx.application.Application;
@@ -103,7 +104,7 @@ public class KarediApp extends Application {
 			controller.setAppContext(appContext);
 
 			txtExtensionFilter = new FileChooser.ExtensionFilter(I18N.get("filechooser.txt_files"), "*.txt");
-			List<String> supportedAudioExtensionsPatterns = appContext.getAudioContext().supportedAudioExtensions()
+			List<String> supportedAudioExtensionsPatterns = AudioContext.supportedAudioExtensions()
 					.stream()
 					.map(ext -> "*." + ext)
 					.toList();

--- a/src/main/java/com/github/nianna/karedi/context/AudioContext.java
+++ b/src/main/java/com/github/nianna/karedi/context/AudioContext.java
@@ -116,7 +116,7 @@ public class AudioContext {
         }));
     }
 
-    public List<String> supportedAudioExtensions() {
+    public static List<String> supportedAudioExtensions() {
         return AudioFileLoader.supportedExtensions();
     }
 

--- a/src/main/java/com/github/nianna/karedi/context/actions/NewSongWizard.java
+++ b/src/main/java/com/github/nianna/karedi/context/actions/NewSongWizard.java
@@ -27,8 +27,8 @@ class NewSongWizard {
 
 	Optional<CreatorResult> start() {
 		Utils.executeUntilFail(
-				this::createSong,
 				this::chooseAudio,
+				this::createSong,
 				this::chooseDirectory,
 				this::setBpm,
 				this::addTags,
@@ -38,6 +38,9 @@ class NewSongWizard {
 
 	private boolean createSong() {
 		EditFilenamesDialog dialog = new EditFilenamesDialog();
+		Optional.ofNullable(audioFile)
+				.map(File::getName)
+				.ifPresent(dialog::initDataFromAudioFilename);
 		dialog.setTitle(I18N.get("dialog.creator.title"));
 		Optional<FilenamesEditResult> optResult = dialog.showAndWait();
 		if (optResult.isPresent()) {

--- a/src/main/java/com/github/nianna/karedi/dialog/ArtistTitleGuesser.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/ArtistTitleGuesser.java
@@ -1,0 +1,27 @@
+package com.github.nianna.karedi.dialog;
+
+import javafx.util.Pair;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class ArtistTitleGuesser {
+
+    private static final String EMPTY = "";
+
+    private ArtistTitleGuesser() {
+
+    }
+
+    static Pair<String, String> guessFromFileName(String fileNameWithoutExtension) {
+        if (fileNameWithoutExtension == null) {
+            return new Pair<>(EMPTY, EMPTY);
+        }
+        Pattern p = Pattern.compile("(.*?) ?- ?(.*)");
+        Matcher m = p.matcher(fileNameWithoutExtension);
+        if (m.matches()) {
+            return new Pair<>(m.group(1), m.group(2));
+        }
+        return new Pair<>(EMPTY, fileNameWithoutExtension);
+    }
+}

--- a/src/main/java/com/github/nianna/karedi/util/Utils.java
+++ b/src/main/java/com/github/nianna/karedi/util/Utils.java
@@ -18,9 +18,12 @@ public final class Utils {
 	}
 
 	public static String getFileExtension(File file) {
-		String name = file.getName();
+		return getFileExtension(file.getName());
+	}
+
+	public static String getFileExtension(String fileName) {
 		try {
-			return name.substring(name.lastIndexOf(".") + 1);
+			return fileName.substring(fileName.lastIndexOf(".") + 1).toLowerCase();
 		} catch (Exception e) {
 			return "";
 		}
@@ -31,7 +34,7 @@ public final class Utils {
 	}
 
 	@SafeVarargs
-	public static final boolean executeUntilFail(Supplier<Boolean>... functions) {
+	public static boolean executeUntilFail(Supplier<Boolean>... functions) {
 		for (int i = 0; i < functions.length; ++i) {
 			if (!functions[i].get()) {
 				return false;

--- a/src/main/resources/Karedi.css
+++ b/src/main/resources/Karedi.css
@@ -123,3 +123,17 @@
 .chart-horizontal-grid-lines {
 	-fx-stroke: #bababa;
 }
+
+.no-arrow-combobox .arrow-button {
+    -fx-background-color: null;
+    -fx-background-insets: 0;
+    -fx-background-radius: 0;
+    -fx-padding: 0.0em 0em 0.0em 0.0em;
+}
+
+.no-arrow-combobox .arrow-button .arrow {
+    -fx-background-color: -fx-mark-highlight-color, -fx-mark-color;
+    -fx-background-insets: 0 0 0 0, 0;
+    -fx-padding: 0em 0em 0em 0em;
+    -fx-shape: null;
+}

--- a/src/main/resources/fxml/EditFilenamesDialogPaneLayout.fxml
+++ b/src/main/resources/fxml/EditFilenamesDialogPaneLayout.fxml
@@ -2,6 +2,7 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.DialogPane?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.Separator?>
@@ -16,7 +17,7 @@
 <!-- <?import org.controlsfx.glyphfont.*?> -->
 
 <fx:root type="javafx.scene.control.DialogPane" xmlns="http://javafx.com/javafx/8.0.60"
-	xmlns:fx="http://javafx.com/fxml/1">
+		 xmlns:fx="http://javafx.com/fxml/1">
 	<content>
 		<ManageableGridPane fx:id="gridPane" hgap="10.0">
 			<columnConstraints>
@@ -25,7 +26,7 @@
 				<ColumnConstraints hgrow="SOMETIMES" minWidth="10.0"
 					prefWidth="200.0" />
 				<ColumnConstraints hgrow="SOMETIMES" />
-				<ColumnConstraints hgrow="SOMETIMES" prefWidth="45.0" />
+				<ColumnConstraints hgrow="SOMETIMES" prefWidth="66.0" />
 				<ColumnConstraints />
 			</columnConstraints>
 			<rowConstraints>
@@ -91,7 +92,7 @@
 				<FilenameTextField fx:id="audioField"
 					GridPane.columnIndex="2" GridPane.rowIndex="7" />
 				<Label text="." GridPane.columnIndex="3" GridPane.rowIndex="7" />
-				<TextField fx:id="audioExtensionField"
+				<ComboBox fx:id="audioExtensionField"
 					GridPane.columnIndex="4" GridPane.rowIndex="7" />
 
 				<Glyph fx:id="coverLinkGlyph" fontFamily="FontAwesome" icon="LINK"

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -159,14 +159,14 @@ tag.edition.tooltip=The edition of the song
 dialog.delete_audio.title=Delete Audio
 dialog.delete_audio.header=Are you sure you want to delete the following audio file?
 
-dialog.creator.title=New Song...
+dialog.creator.title=Fill in basic data
 dialog.creator.add_info.title=Add song info
 dialog.creator.add_info.header=Please specify some additional information:
 dialog.creator.add_info.description=Ultrastar txt file format enables you to specify song metadata by using tags.\n	Supplying this information is not necessary, but recommended (at least in case of the tags from the top group).\n	You can learn more about a particular tag by hovering the mouse over the label.\n\nYou can skip this step and edit/add these (and other) tags later.
 
 dialog.creator.choose_audio.title=Choose audio file
 dialog.creator.choose_audio.header=Please choose the song''s audio file
-dialog.creator.choose_audio.description=Please choose an MP3 file for your song.\n	It ought to be encoded with constant bitrate and unnecessary silence from the beginning and end should be trimmed.\n\nYou can skip this step and import audio later.
+dialog.creator.choose_audio.description=Please choose an audio file with your song in one of the supported formats.\nUnnecessary silence from the beginning and end should be trimmed.\n\nYou can skip this step and import audio later.
 
 dialog.creator.choose_dir.title=Choose output directory
 dialog.creator.choose_dir.header=Please choose the directory for your song

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -159,14 +159,14 @@ tag.edition.tooltip=The edition of the song
 dialog.delete_audio.title=Delete Audio
 dialog.delete_audio.header=Are you sure you want to delete the following audio file?
 
-dialog.creator.title=New Song...
+dialog.creator.title=Fill in basic data
 dialog.creator.add_info.title=Add song info
 dialog.creator.add_info.header=Please specify some additional information:
 dialog.creator.add_info.description=Ultrastar txt file format enables you to specify song metadata by using tags.\n	Supplying this information is not necessary, but recommended (at least in case of the tags from the top group).\n	You can learn more about a particular tag by hovering the mouse over the label.\n\nYou can skip this step and edit/add these (and other) tags later.
 
 dialog.creator.choose_audio.title=Choose audio file
 dialog.creator.choose_audio.header=Please choose the song''s audio file
-dialog.creator.choose_audio.description=Please choose an MP3 file for your song.\n	It ought to be encoded with constant bitrate and unnecessary silence from the beginning and end should be trimmed.\n\nYou can skip this step and import audio later.
+dialog.creator.choose_audio.description=Please choose an audio file with your song in one of the supported formats.\nUnnecessary silence from the beginning and end should be trimmed.\n\nYou can skip this step and import audio later.
 
 dialog.creator.choose_dir.title=Choose output directory
 dialog.creator.choose_dir.header=Please choose the directory for your song

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -159,14 +159,14 @@ tag.edition.tooltip=Edycja
 dialog.delete_audio.title=Usu\u0144 plik audio
 dialog.delete_audio.header=Czy jeste\u015B pewien, \u017Ce chcesz usun\u0105\u0107 ten plik audio?
 
-dialog.creator.title=Nowa piosenka...
+dialog.creator.title=Uzupe\u0142nij podstawowe informacje
 dialog.creator.add_info.title=Dodaj informacje
 dialog.creator.add_info.header=Prosz\u0119 podaj dodatkowe informacje o piosence
-dialog.creator.add_info.description=Format plików tekstowych obs\u0142ugiwany przez Ultrastara pozwala na przechowywanie metainformacji w postaci tagów. 	Podawanie tych informacji jest nieobowi\u0105zkowe, ale zalecane (zw\u0142aszcza w przypadku tagów z górnej grupy).\n	Mo\u017Cesz dowiedzie\u0107 si\u0119 wi\u0119cej o danym tagu, naje\u017Cd\u017Caj\u0105c na niego.\n\nMo\u017Cesz pomin\u0105\u0107 ten krok i doda\u0107 te (lub inne) tagi pó\u017Aniej.
+dialog.creator.add_info.description=Format plików tekstowych obs\u0142ugiwany przez Ultrastara pozwala na przechowywanie metadanych w postaci tagów. 	Podawanie tych informacji jest nieobowi\u0105zkowe, ale zalecane (zw\u0142aszcza w przypadku tagów z górnej grupy).\n	Mo\u017Cesz dowiedzie\u0107 si\u0119 wi\u0119cej o danym tagu, naje\u017Cd\u017Caj\u0105c na niego.\n\nMo\u017Cesz pomin\u0105\u0107 ten krok i doda\u0107 te (lub inne) tagi pó\u017Aniej.
 
 dialog.creator.choose_audio.title=Wybierz plik audio
-dialog.creator.choose_audio.header=Prosz\u0119 wybierz plik audio zawieraj\u0105cy t\u0119 piosenk\u0119
-dialog.creator.choose_audio.description=Wybierz w\u0142a\u015Bciwy plik mp3.\n	Musi by\u0107 zakodowany z wykorzystaniem sta\u0142ej przep\u0142ywno\u015Bci (CBR), a zb\u0119dna cisza z pocz\u0105tku i ko\u0144ca powinna zosta\u0107 usuni\u0119ta.\n\nMo\u017Cesz pomin\u0105\u0107 ten krok i doda\u0107 plik muzyczny pó\u017Aniej.
+dialog.creator.choose_audio.header=Prosz\u0119 wybierz plik audio z piosenk\u0105
+dialog.creator.choose_audio.description=Wybierz w\u0142a\u015Bciwy plik audio.\nZb\u0119dna cisza z pocz\u0105tku i ko\u0144ca powinna zosta\u0107 usuni\u0119ta.\n\nMo\u017Cesz pomin\u0105\u0107 ten krok i doda\u0107 plik muzyczny pó\u017Aniej.
 
 dialog.creator.choose_dir.title=Wybierz folder docelowy
 dialog.creator.choose_dir.header=Wybierz docelowy folder dla piosenki

--- a/src/test/java/com/github/nianna/karedi/dialog/ArtistTitleGuesserTest.java
+++ b/src/test/java/com/github/nianna/karedi/dialog/ArtistTitleGuesserTest.java
@@ -1,0 +1,50 @@
+package com.github.nianna.karedi.dialog;
+
+import javafx.util.Pair;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ArtistTitleGuesserTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {""})
+    @NullSource
+    public void shouldGuessEmptyValuesForEmptyInput(String filename) {
+        Pair<String, String> result = ArtistTitleGuesser.guessFromFileName(filename);
+
+        assertEquals("", result.getKey());
+        assertEquals("", result.getValue());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"   ", "test", "lorem ipsum"})
+    public void shouldReturnEmptyArtistAndWholeFilenameAsTitleIfNoDash(String filename) {
+        Pair<String, String> result = ArtistTitleGuesser.guessFromFileName(filename);
+
+        assertEquals("", result.getKey());
+        assertEquals(filename, result.getValue());
+    }
+
+    @Test
+    public void shouldSplitArtistAndTitleOnFirstDash() {
+        String filename = "artist continued-title-continued further";
+        Pair<String, String> result = ArtistTitleGuesser.guessFromFileName(filename);
+
+        assertEquals("artist continued", result.getKey());
+        assertEquals("title-continued further", result.getValue());
+    }
+
+    @Test
+    public void shouldSplitArtistAndTitleOnFirstDashAndRemoveSpacesAroundThatDash() {
+        String filename = "artist continued - title - continued further";
+        Pair<String, String> result = ArtistTitleGuesser.guessFromFileName(filename);
+
+        assertEquals("artist continued", result.getKey());
+        assertEquals("title - continued further", result.getValue());
+    }
+
+}


### PR DESCRIPTION
Reorder steps - first let the user choose the audio, then ask for artist & title.

If audio file is chosen:
 * extension is automatically filled in artst&title step and can't be changed
 * Karedi tries to guess artist and title based on the chosen filename

If audio file was not chosen, extension can be chosen by the user from the list of all supported extensions.