### PR TITLE
Add option to remember library directory in new song wizard

### DIFF
--- a/src/main/java/com/github/nianna/karedi/KarediApp.java
+++ b/src/main/java/com/github/nianna/karedi/KarediApp.java
@@ -248,7 +248,9 @@ public class KarediApp extends Application {
 
 		public void setInitialDirectory(File directory) {
 			directoryChooser.setInitialDirectory(directory);
-			fileChooser.setInitialDirectory(directory);
+			if (directory.exists()) {
+				fileChooser.setInitialDirectory(directory);
+			}
 		}
 
 		private File getDirectory() {

--- a/src/main/java/com/github/nianna/karedi/Settings.java
+++ b/src/main/java/com/github/nianna/karedi/Settings.java
@@ -1,8 +1,9 @@
 package com.github.nianna.karedi;
 
-import javafx.scene.paint.Color;
 import com.github.nianna.karedi.util.ColorUtils;
+import javafx.scene.paint.Color;
 
+import java.io.File;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -30,6 +31,8 @@ public final class Settings {
 
 	private static final String TRACKS_COLOR_KEY = "ui_tracks_colors_";
 	private static final String TRACKS_FONT_COLOR_KEY = "ui_tracks_font_colors_";
+
+	private static final String NEW_SONG_WIZARD_LIBRARY_DIR = "ui_new_song_wizard_library_dir";
 
 	private static final Preferences PREFERENCES = Preferences.userNodeForPackage(Settings.class);
 
@@ -104,6 +107,20 @@ public final class Settings {
 
 	public static boolean isDisplayNoteNodeUnderBarEnabled() {
 		return PREFERENCES.getBoolean(DISPLAY_NOTENODE_UNDERBAR_KEY, true);
+	}
+
+	public static void setNewSongWizardLibraryDirectory(File file) {
+		if (file != null) {
+			PREFERENCES.put(NEW_SONG_WIZARD_LIBRARY_DIR, file.getAbsolutePath());
+		} else {
+			PREFERENCES.remove(NEW_SONG_WIZARD_LIBRARY_DIR);
+		}
+	}
+
+	public static Optional<File> getNewSongWizardLibraryDirectory() {
+		String absolutePath = PREFERENCES.get(NEW_SONG_WIZARD_LIBRARY_DIR, null);
+		return Optional.ofNullable(absolutePath)
+				.map(File::new);
 	}
 
 }

--- a/src/main/java/com/github/nianna/karedi/context/actions/NewSongWizard.java
+++ b/src/main/java/com/github/nianna/karedi/context/actions/NewSongWizard.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.github.nianna.karedi.I18N;
+import com.github.nianna.karedi.Settings;
 import com.github.nianna.karedi.dialog.AddSongInfoDialog;
 import com.github.nianna.karedi.dialog.ChooseAudioFileDialog;
 import com.github.nianna.karedi.dialog.ChooseDirectoryDialog;
@@ -72,6 +73,11 @@ class NewSongWizard {
 	}
 
 	private boolean chooseDirectory() {
+		Optional<File> rememberedDir = Settings.getNewSongWizardLibraryDirectory();
+		if (rememberedDir.isPresent() && rememberedDir.get().exists()) {
+			outputDir = rememberedDir.get();
+			return true;
+		}
 		ChooseDirectoryDialog dialog = new ChooseDirectoryDialog();
 		Optional<Optional<File>> result = dialog.showAndWait();
 		if (result.isPresent()) {

--- a/src/main/java/com/github/nianna/karedi/context/actions/ShowPreferencesAction.java
+++ b/src/main/java/com/github/nianna/karedi/context/actions/ShowPreferencesAction.java
@@ -17,6 +17,7 @@ class ShowPreferencesAction extends KarediAction {
         dialog.showAndWait().ifPresent(result -> {
             Settings.setLocale(result.getSelectedLocale());
             Settings.setDisplayNoteNodeUnderBarEnabled(result.isDisplayNoteNodeUnderBarEnabled());
+            Settings.setNewSongWizardLibraryDirectory(result.getNewSongWizardLibraryDir());
         });
     }
 }

--- a/src/main/java/com/github/nianna/karedi/dialog/ChooseAudioFileDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/ChooseAudioFileDialog.java
@@ -7,6 +7,7 @@ public class ChooseAudioFileDialog extends ChooseFileDialog {
 
 	public ChooseAudioFileDialog() {
 		super(KarediApp.getInstance()::getAudioFileToOpen);
+		DialogUtils.loadPane(this, getClass().getResource("/fxml/ChooseFileDialogPaneLayout.fxml"));
 		setTitle(I18N.get("dialog.creator.choose_audio.title"));
 		setHeaderText(I18N.get("dialog.creator.choose_audio.header"));
 		setDescription(I18N.get("dialog.creator.choose_audio.description"));

--- a/src/main/java/com/github/nianna/karedi/dialog/ChooseDirectoryDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/ChooseDirectoryDialog.java
@@ -2,14 +2,27 @@ package com.github.nianna.karedi.dialog;
 
 import com.github.nianna.karedi.I18N;
 import com.github.nianna.karedi.KarediApp;
+import com.github.nianna.karedi.Settings;
+import javafx.fxml.FXML;
+import javafx.scene.control.CheckBox;
 
 public class ChooseDirectoryDialog extends ChooseFileDialog {
 
+	@FXML
+	private CheckBox rememberDirectoryCheckBox;
+
 	public ChooseDirectoryDialog() {
 		super(KarediApp.getInstance()::getDirectory);
+		DialogUtils.loadPane(this, getClass().getResource("/fxml/ChooseDirectoryDialogPaneLayout.fxml"));
 		setTitle(I18N.get("dialog.creator.choose_dir.title"));
 		setHeaderText(I18N.get("dialog.creator.choose_dir.header"));
 		setDescription(I18N.get("dialog.creator.choose_dir.description"));
+	}
+
+	protected void onOkClicked() {
+		if (rememberDirectoryCheckBox.isSelected()) {
+			Settings.setNewSongWizardLibraryDirectory(super.getData());
+		}
 	}
 
 }

--- a/src/main/java/com/github/nianna/karedi/dialog/ChooseFileDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/ChooseFileDialog.java
@@ -15,7 +15,6 @@ public class ChooseFileDialog extends SkippableDialog<File> {
 
 	public ChooseFileDialog(Supplier<File> fileSupplier) {
 		this.fileSupplier = fileSupplier;
-		DialogUtils.loadPane(this, getClass().getResource("/fxml/ChooseFileDialogPaneLayout.fxml"));
 	}
 
 	@FXML

--- a/src/main/java/com/github/nianna/karedi/dialog/PreferencesDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/PreferencesDialog.java
@@ -1,17 +1,22 @@
 package com.github.nianna.karedi.dialog;
 
+import com.github.nianna.karedi.I18N;
+import com.github.nianna.karedi.KarediApp;
+import com.github.nianna.karedi.Settings;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
+import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.Dialog;
+import javafx.scene.control.TextField;
 import javafx.util.StringConverter;
-import com.github.nianna.karedi.I18N;
-import com.github.nianna.karedi.Settings;
 
+import java.io.File;
 import java.util.Locale;
+import java.util.Optional;
 
 public class PreferencesDialog extends Dialog<PreferencesResult> {
 
@@ -21,23 +26,62 @@ public class PreferencesDialog extends Dialog<PreferencesResult> {
 	@FXML
 	private CheckBox displayNoteNodeUnderBarEnabledCheckBox;
 
+	@FXML
+	private TextField newSongWizardLibraryDirTextField;
+
+	@FXML
+	private Button newSongWizardLibraryDirClearButton;
+
+	@FXML
+	private Button newSongWizardLibraryDirChooseButton;
+
+	private File newSongWizardCurrentLibraryDir;
+
 	public PreferencesDialog() {
 		DialogUtils.loadPane(this, getClass().getResource("/fxml/PreferencesLayout.fxml"));
 		setTitle(I18N.get("dialog.preferences.title"));
 		initGeneralTab();
 		initDisplayTab();
+		initNewSongWizardTab();
 		getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
 
 		setResultConverter(type -> {
 			if (type == ButtonType.OK) {
 				return new PreferencesResult(
 						languageSelect.getSelectionModel().getSelectedItem(),
-						displayNoteNodeUnderBarEnabledCheckBox.isSelected()
+						displayNoteNodeUnderBarEnabledCheckBox.isSelected(),
+						newSongWizardCurrentLibraryDir
 				);
 			}
 			return null;
 		});
 
+	}
+
+	private void initNewSongWizardTab() {
+		newSongWizardCurrentLibraryDir = Settings.getNewSongWizardLibraryDirectory().orElse(null);
+		resetNewSongWizardLibraryDirLabelValue();
+		newSongWizardLibraryDirChooseButton.setOnAction(event -> {
+			Optional.ofNullable(KarediApp.getInstance().getDirectory())
+					.ifPresent(newDir -> {
+						newSongWizardCurrentLibraryDir = newDir;
+						resetNewSongWizardLibraryDirLabelValue();
+					});
+		});
+		newSongWizardLibraryDirClearButton.setOnAction(event -> {
+			newSongWizardCurrentLibraryDir = null;
+			resetNewSongWizardLibraryDirLabelValue();
+		});
+	}
+
+	private void resetNewSongWizardLibraryDirLabelValue() {
+		newSongWizardLibraryDirTextField.clear();
+		if (newSongWizardCurrentLibraryDir != null) {
+			newSongWizardLibraryDirTextField.setText(newSongWizardCurrentLibraryDir.getAbsolutePath());
+			newSongWizardLibraryDirClearButton.setDisable(false);
+		} else {
+			newSongWizardLibraryDirClearButton.setDisable(true);
+		}
 	}
 
 	private void initDisplayTab() {

--- a/src/main/java/com/github/nianna/karedi/dialog/PreferencesResult.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/PreferencesResult.java
@@ -1,5 +1,6 @@
 package com.github.nianna.karedi.dialog;
 
+import java.io.File;
 import java.util.Locale;
 
 public class PreferencesResult {
@@ -8,9 +9,14 @@ public class PreferencesResult {
 
     private final boolean displayNoteNodeUnderBarEnabled;
 
-    public PreferencesResult(Locale selectedLocale, boolean displayNoteNodeUnderBarEnabled) {
+    private final File newSongWizardLibraryDir;
+
+    public PreferencesResult(Locale selectedLocale,
+                             boolean displayNoteNodeUnderBarEnabled,
+                             File newSongWizardLibraryDir) {
         this.selectedLocale = selectedLocale;
         this.displayNoteNodeUnderBarEnabled = displayNoteNodeUnderBarEnabled;
+        this.newSongWizardLibraryDir = newSongWizardLibraryDir;
     }
 
     public Locale getSelectedLocale() {
@@ -19,5 +25,9 @@ public class PreferencesResult {
 
     public boolean isDisplayNoteNodeUnderBarEnabled() {
         return displayNoteNodeUnderBarEnabled;
+    }
+
+    public File getNewSongWizardLibraryDir() {
+        return newSongWizardLibraryDir;
     }
 }

--- a/src/main/java/com/github/nianna/karedi/dialog/SkippableDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/SkippableDialog.java
@@ -15,6 +15,7 @@ public abstract class SkippableDialog<T> extends Dialog<Optional<T>> {
 
 		setResultConverter(dialogButtonType -> {
 			if (dialogButtonType == ButtonType.OK) {
+				onOkClicked();
 				return Optional.of(getData());
 			}
 			if (dialogButtonType == SKIP_TYPE) {
@@ -22,6 +23,10 @@ public abstract class SkippableDialog<T> extends Dialog<Optional<T>> {
 			}
 			return null;
 		});
+	}
+
+	protected void onOkClicked() {
+
 	}
 
 	protected abstract T getData();

--- a/src/main/resources/fxml/ChooseDirectoryDialogPaneLayout.fxml
+++ b/src/main/resources/fxml/ChooseDirectoryDialogPaneLayout.fxml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.DialogPane?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.RowConstraints?>
+
+<?import javafx.scene.control.CheckBox?>
+<fx:root minWidth="250.0" type="javafx.scene.control.DialogPane"
+		 xmlns="http://javafx.com/javafx/8.0.60" xmlns:fx="http://javafx.com/fxml/1">
+	<content>
+		<GridPane hgap="10.0">
+			<columnConstraints>
+				<ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
+				<ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
+			</columnConstraints>
+			<rowConstraints>
+				<RowConstraints minHeight="10.0" prefHeight="30.0"
+					vgrow="SOMETIMES" />
+				<RowConstraints minHeight="10.0" prefHeight="30.0"
+								vgrow="SOMETIMES" />
+			</rowConstraints>
+			<children>
+				<TextField fx:id="pathTextField" editable="false"
+					focusTraversable="false" GridPane.hgrow="ALWAYS" />
+				<Button mnemonicParsing="false" onAction="#handleBrowse"
+					text="%common.browse" GridPane.columnIndex="1" GridPane.hgrow="NEVER" />
+				<CheckBox fx:id="rememberDirectoryCheckBox"  GridPane.columnIndex="0" GridPane.rowIndex="1" text="%dialog.creator.choose_dir.remember" />
+			</children>
+		</GridPane>
+	</content>
+</fx:root>

--- a/src/main/resources/fxml/PreferencesLayout.fxml
+++ b/src/main/resources/fxml/PreferencesLayout.fxml
@@ -15,6 +15,8 @@
 <!-- <?import org.controlsfx.glyphfont.*?> -->
 
 <?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.Button?>
 <fx:root type="javafx.scene.control.DialogPane" xmlns="http://javafx.com/javafx/8.0.60" xmlns:fx="http://javafx.com/fxml/1">
 	<content>
 		<TabPane>
@@ -25,7 +27,7 @@
                      <children>
       						<GridPane fx:id="gridPane1" hgap="10.0" vgap="10.0">
       							<columnConstraints>
-      								<ColumnConstraints hgrow="SOMETIMES" />
+      								<ColumnConstraints hgrow="NEVER" />
       								<ColumnConstraints hgrow="SOMETIMES" prefWidth="200.0" />
       								<ColumnConstraints />
       							</columnConstraints>
@@ -52,7 +54,7 @@
                   </VBox>
 					</content>
 				</Tab>
-            <Tab text="%dialog.preferences.display">
+                <Tab text="%dialog.preferences.editor">
                <content>
                   <VBox>
                      <children>
@@ -63,7 +65,7 @@
                               <ColumnConstraints />
                            </columnConstraints>
                            <children>
-                              <Label text="%dialog.preferences.display.notenode_underbar_enabled.label" GridPane.rowIndex="1" />
+                              <Label text="%dialog.preferences.editor.notenode_underbar_enabled.label" GridPane.rowIndex="1" />
                               <CheckBox fx:id="displayNoteNodeUnderBarEnabledCheckBox" prefWidth="200.0" GridPane.columnIndex="1" GridPane.rowIndex="1" />
                            </children>
                            <rowConstraints>
@@ -85,6 +87,34 @@
                   </VBox>
                </content>
             </Tab>
+                <Tab text="%dialog.preferences.new_song_wizard">
+                    <content>
+                        <VBox>
+                            <children>
+                                <GridPane fx:id="gridPaneNewSongWizard" hgap="10.0" vgap="10.0">
+                                    <columnConstraints>
+                                        <ColumnConstraints hgrow="NEVER" />
+                                        <ColumnConstraints hgrow="SOMETIMES" prefWidth="200.0" />
+                                        <ColumnConstraints />
+                                        <ColumnConstraints />
+                                    </columnConstraints>
+                                    <children>
+                                        <Label text="%dialog.preferences.new_song_wizard.library_dir.label"  />
+                                        <TextField fx:id="newSongWizardLibraryDirTextField" editable="false" GridPane.columnIndex="1" />
+                                        <Button fx:id="newSongWizardLibraryDirChooseButton" text="%dialog.preferences.new_song_wizard.library_dir.choose" GridPane.columnIndex="2" />
+                                        <Button fx:id="newSongWizardLibraryDirClearButton" disable="true" text="%dialog.preferences.new_song_wizard.library_dir.clear" GridPane.columnIndex="3" />
+                                    </children>
+                                    <rowConstraints>
+                                        <RowConstraints />
+                                    </rowConstraints>
+                                </GridPane>
+                            </children>
+                            <padding>
+                                <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                            </padding>
+                        </VBox>
+                    </content>
+                </Tab>
 			</tabs>
 		</TabPane>
 	</content>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -171,6 +171,7 @@ dialog.creator.choose_audio.description=Please choose an audio file with your so
 dialog.creator.choose_dir.title=Choose output directory
 dialog.creator.choose_dir.header=Please choose the directory for your song
 dialog.creator.choose_dir.description=Please choose the directory in which your new song should be created.\n	To ensure that Ultrastar can find your song, please make sure that the chosen directory is one of the song directories from Ultrastar''s config file or their subdirectory.\n	The program will try to:\n- create a subfolder for your new song,\n- copy & rename the audio file chosen in the previous step (if applicable),\n- save newly created TXT file.\n\nYou can skip this step and do it manually later.
+dialog.creator.choose_dir.remember=Remember this directory
 
 dialog.creator.set_bpm.title=Set BPM
 dialog.creator.set_bpm.header=Please set your song''s BPM
@@ -197,13 +198,17 @@ dialog.tag.value=Value:
 
 dialog.preferences.title=Preferences
 dialog.preferences.general=General
-dialog.preferences.display=Display
+dialog.preferences.editor=Editor
+dialog.preferences.new_song_wizard=New song wizard
 dialog.preferences.languages.label=Language:*
 dialog.preferences.language.en_GB=British English
 dialog.preferences.language.pl_PL=Polish
 dialog.preferences.restart_required=* Restart application for this change to take effect
 dialog.preferences.song_reload_required=* Reload song for this change to take effect
-dialog.preferences.display.notenode_underbar_enabled.label=Show tone and length under notes in editor:*
+dialog.preferences.editor.notenode_underbar_enabled.label=Show tone and length under notes in editor:*
+dialog.preferences.new_song_wizard.library_dir.label=Library dir:
+dialog.preferences.new_song_wizard.library_dir.choose=Choose
+dialog.preferences.new_song_wizard.library_dir.clear=Clear
 
 dialog.track_export.title=Choose tracks to export
 dialog.track_export.header=Please choose {0, number, integer}:

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -171,6 +171,7 @@ dialog.creator.choose_audio.description=Please choose an audio file with your so
 dialog.creator.choose_dir.title=Choose output directory
 dialog.creator.choose_dir.header=Please choose the directory for your song
 dialog.creator.choose_dir.description=Please choose the directory in which your new song should be created.\n	To ensure that Ultrastar can find your song, please make sure that the chosen directory is one of the song directories from Ultrastar''s config file or their subdirectory.\n	The program will try to:\n- create a subfolder for your new song,\n- copy & rename the audio file chosen in the previous step (if applicable),\n- save newly created TXT file.\n\nYou can skip this step and do it manually later.
+dialog.creator.choose_dir.remember=Remember this directory
 
 dialog.creator.set_bpm.title=Set BPM
 dialog.creator.set_bpm.header=Please set your song''s BPM
@@ -197,13 +198,17 @@ dialog.tag.value=Value:
 
 dialog.preferences.title=Preferences
 dialog.preferences.general=General
-dialog.preferences.display=Display
+dialog.preferences.editor=Editor
+dialog.preferences.new_song_wizard=New song wizard
 dialog.preferences.languages.label=Language:*
 dialog.preferences.language.en_GB=British English
 dialog.preferences.language.pl_PL=Polish
 dialog.preferences.restart_required=* Restart application for this change to take effect
 dialog.preferences.song_reload_required=* Reload song for this change to take effect
-dialog.preferences.display.notenode_underbar_enabled.label=Show tone and length under notes in editor:*
+dialog.preferences.editor.notenode_underbar_enabled.label=Show tone and length under notes in editor:*
+dialog.preferences.new_song_wizard.library_dir.label=Library dir:
+dialog.preferences.new_song_wizard.library_dir.choose=Choose
+dialog.preferences.new_song_wizard.library_dir.clear=Clear
 
 dialog.track_export.title=Choose tracks to export
 dialog.track_export.header=Please choose {0, number, integer}:

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -171,6 +171,7 @@ dialog.creator.choose_audio.description=Wybierz w\u0142a\u015Bciwy plik audio.\n
 dialog.creator.choose_dir.title=Wybierz folder docelowy
 dialog.creator.choose_dir.header=Wybierz docelowy folder dla piosenki
 dialog.creator.choose_dir.description=Wybierz folder docelowy, w którym Twoja nowa piosenka powinna zosta\u0107 zapisana.\n	\u017Beby UltraStar potrafi\u0142 j\u0105 odnale\u017A\u0107, upewnij si\u0119, \u017Ce wybrany katalog jest jednym z podfolderów \u015Bcie\u017Cki sprecyzowanej w pliku konfiguracyjnym gry.\n	Karedi kolejno spróbuje:\n- utworzy\u0107 podfolder dla nowej piosenki,\n- skopiowa\u0107 i odpowiednio nazwa\u0107 plik audio z poprzedniego etapu (je\u015Bli dotyczy),\n- zapisa\u0107 nowoutworzony plik TXT.\n\nMo\u017Cesz pomin\u0105\u0107 ten krok i zrobi\u0107 to r\u0119cznie pó\u017Aniej.
+dialog.creator.choose_dir.remember=Zapami\u0119taj ten folder
 
 dialog.creator.set_bpm.title=Ustaw BPM
 dialog.creator.set_bpm.header=Ustaw w\u0142a\u015Bciw\u0105 warto\u015B\u0107 BPM
@@ -199,13 +200,17 @@ dialog.tag.value=Warto\u015B\u0107:
 
 dialog.preferences.title=Ustawienia
 dialog.preferences.general=Ogólne
-dialog.preferences.display=Wy\u015Bwietlanie
+dialog.preferences.editor=Edytor
+dialog.preferences.new_song_wizard=Kreator piosenek
 dialog.preferences.languages.label=J\u0119zyk:*
 dialog.preferences.language.en_GB=angielski
 dialog.preferences.language.pl_PL=polski
 dialog.preferences.restart_required=* Zrestartuj aplikacj\u0119, aby zobaczy\u0107 efekt
 dialog.preferences.song_reload_required=* Prze\u0142aduj piosenk\u0119, aby zobaczy\u0107 efekt
-dialog.preferences.display.notenode_underbar_enabled.label=Pokazuj d\u0142ugo\u015B\u0107 i wysoko\u015B\u0107 pod nutami w edytorze:*
+dialog.preferences.editor.notenode_underbar_enabled.label=Pokazuj d\u0142ugo\u015B\u0107 i wysoko\u015B\u0107 pod nutami w edytorze:*
+dialog.preferences.new_song_wizard.library_dir.label=Folder do zapisu:
+dialog.preferences.new_song_wizard.library_dir.choose=Wybierz
+dialog.preferences.new_song_wizard.library_dir.clear=Wyczy\u015B\u0107
 
 dialog.track_export.title=Wybierz \u015Bcie\u017Cki
 dialog.track_export.header=Prosz\u0119 wybierz {0, number, integer}:


### PR DESCRIPTION
Added "Remember this directory" checkbox in choose directory step in New song wizard.
If clicked then app will remember the library dir and as long as it still exists, this step will be skipped in the wizard.

Remembered dir can be cleared/changed in app preferences.