### PR TITLE
Fix/recreate multiplayer tags on export

### DIFF
--- a/src/main/java/com/github/nianna/karedi/command/track/ChangeTrackNameCommand.java
+++ b/src/main/java/com/github/nianna/karedi/command/track/ChangeTrackNameCommand.java
@@ -33,7 +33,7 @@ public class ChangeTrackNameCommand extends CommandComposite {
             updateTagsValue(existingMultiplayerTagsForTrack);
             String defaultMultiplayerTagKeyForTrack = MultiplayerTags.getTagKeyForTrackNumber(
                     trackIndex,
-                    track.getSong().formatSpecificationVersion().orElse(null)
+                    track.getSong().getFormatSpecificationVersion()
             );
             if (!track.getSong().hasTag(defaultMultiplayerTagKeyForTrack)) {
                 addSubCommand(new ChangeTagValueCommand(track.getSong(), defaultMultiplayerTagKeyForTrack, newValue));

--- a/src/main/java/com/github/nianna/karedi/context/TxtContext.java
+++ b/src/main/java/com/github/nianna/karedi/context/TxtContext.java
@@ -10,7 +10,6 @@ import com.github.nianna.karedi.song.tag.TagKey;
 import com.github.nianna.karedi.txt.TxtFacade;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.ReadOnlyObjectWrapper;
-import javafx.collections.ObservableList;
 
 import java.io.File;
 import java.util.List;
@@ -87,7 +86,7 @@ public class TxtContext {
         return false;
     }
 
-    public void exportSongToFile(File file, ObservableList<Tag> tags, List<SongTrack> tracks) {
+    public void exportSongToFile(File file, List<Tag> tags, List<SongTrack> tracks) {
         txtFacade.exportSongToFile(file, tags, tracks);
     }
 

--- a/src/main/java/com/github/nianna/karedi/context/actions/ExportTracksAction.java
+++ b/src/main/java/com/github/nianna/karedi/context/actions/ExportTracksAction.java
@@ -78,6 +78,7 @@ class ExportTracksAction extends ContextfulKarediAction {
 
     private static List<Tag> recreatedMultiplayerTags(Song song, List<SongTrack> tracks) {
         return IntStream.range(0, tracks.size())
+                .filter(i -> tracks.get(i).hasCustomName())
                 .mapToObj(i ->
                         new Tag(
                                 MultiplayerTags.getTagKeyForTrackNumber(i, song.getFormatSpecificationVersion()),

--- a/src/main/java/com/github/nianna/karedi/context/actions/ExportTracksAction.java
+++ b/src/main/java/com/github/nianna/karedi/context/actions/ExportTracksAction.java
@@ -4,19 +4,24 @@ import com.github.nianna.karedi.KarediApp;
 import com.github.nianna.karedi.context.AppContext;
 import com.github.nianna.karedi.dialog.ChooseTracksDialog;
 import com.github.nianna.karedi.dialog.ExportWithErrorsAlert;
+import com.github.nianna.karedi.song.Song;
 import com.github.nianna.karedi.song.SongTrack;
+import com.github.nianna.karedi.song.tag.MultiplayerTags;
+import com.github.nianna.karedi.song.tag.Tag;
 import javafx.event.ActionEvent;
 import javafx.scene.control.ButtonType;
 
 import java.io.File;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 class ExportTracksAction extends ContextfulKarediAction {
 
     private int trackCount;
 
-     ExportTracksAction(AppContext appContext, int trackCount) {
+    ExportTracksAction(AppContext appContext, int trackCount) {
         super(appContext);
         this.trackCount = trackCount;
         activeSongContext.activeSongProperty().addListener((obsVal, oldVal, newVal) -> {
@@ -31,7 +36,7 @@ class ExportTracksAction extends ContextfulKarediAction {
 
     @Override
     protected void onAction(ActionEvent event) {
-        if (activeSongContext.getSong().getProblems().size() > 0) {
+        if (!activeSongContext.getSong().getProblems().isEmpty()) {
             new ExportWithErrorsAlert().showAndWait().filter(result -> result == ButtonType.OK)
                     .ifPresent(ok -> export());
         } else {
@@ -53,7 +58,33 @@ class ExportTracksAction extends ContextfulKarediAction {
         }
 
         File file = KarediApp.getInstance().getTxtFileToSave(getInitialFileName());
-        txtContext.exportSongToFile(file, activeSongContext.getSong().getTags(), tracks);
+        txtContext.exportSongToFile(file, prepareTags(tracks), tracks);
+    }
+
+    private List<Tag> prepareTags(List<SongTrack> tracks) {
+        Song song = activeSongContext.getSong();
+        List<Tag> tags = nonMultiplayerTags(song);
+        if (tracks.size() > 1) {
+            tags.addAll(recreatedMultiplayerTags(song, tracks));
+        }
+        return tags;
+    }
+
+    private static List<Tag> nonMultiplayerTags(Song song) {
+        return song.getTags().stream()
+                .filter(tag -> !MultiplayerTags.isANameTag(tag))
+                .collect(Collectors.toList());
+    }
+
+    private static List<Tag> recreatedMultiplayerTags(Song song, List<SongTrack> tracks) {
+        return IntStream.range(0, tracks.size())
+                .mapToObj(i ->
+                        new Tag(
+                                MultiplayerTags.getTagKeyForTrackNumber(i, song.getFormatSpecificationVersion()),
+                                tracks.get(i).getName()
+                        )
+                )
+                .toList();
     }
 
     private String getInitialFileName() {

--- a/src/main/java/com/github/nianna/karedi/song/Song.java
+++ b/src/main/java/com/github/nianna/karedi/song/Song.java
@@ -334,6 +334,10 @@ public class Song implements IntBounded, Problematic {
 				.flatMap(FormatSpecification::tryParse);
 	}
 
+	public FormatSpecification getFormatSpecificationVersion() {
+		return formatSpecificationVersion().orElse(null);
+	}
+
 	public static class Medley implements Observable {
 		private int startBeat;
 		private int endBeat;

--- a/src/main/java/com/github/nianna/karedi/song/SongTrack.java
+++ b/src/main/java/com/github/nianna/karedi/song/SongTrack.java
@@ -165,6 +165,10 @@ public class SongTrack implements IntBounded, Problematic, MovableContainer<Song
 		name.set(value);
 	}
 
+	public boolean hasCustomName() {
+		return !SongTrack.getDefaultTrackName(getPlayer()).equals(getName());
+	}
+
 	public Integer indexOf(SongLine line) {
 		return sortedLines.indexOf(line);
 	}

--- a/src/main/java/com/github/nianna/karedi/txt/saver/SongDisassembler.java
+++ b/src/main/java/com/github/nianna/karedi/txt/saver/SongDisassembler.java
@@ -1,5 +1,9 @@
 package com.github.nianna.karedi.txt.saver;
 
+import com.github.nianna.karedi.song.Note;
+import com.github.nianna.karedi.song.SongLine;
+import com.github.nianna.karedi.song.SongTrack;
+import com.github.nianna.karedi.song.tag.Tag;
 import com.github.nianna.karedi.txt.parser.element.EndOfSongElement;
 import com.github.nianna.karedi.txt.parser.element.LineBreakElement;
 import com.github.nianna.karedi.txt.parser.element.NoteElement;
@@ -7,10 +11,6 @@ import com.github.nianna.karedi.txt.parser.element.NoteElementType;
 import com.github.nianna.karedi.txt.parser.element.TagElement;
 import com.github.nianna.karedi.txt.parser.element.TrackElement;
 import com.github.nianna.karedi.txt.parser.element.VisitableSongElement;
-import com.github.nianna.karedi.song.Note;
-import com.github.nianna.karedi.song.SongLine;
-import com.github.nianna.karedi.song.SongTrack;
-import com.github.nianna.karedi.song.tag.Tag;
 
 import java.util.List;
 import java.util.function.Function;
@@ -37,13 +37,13 @@ public class SongDisassembler {
 	private Stream<VisitableSongElement> disassembleTracks(List<SongTrack> tracks) {
 		boolean shouldSkipFirstPlayerTag = tracks.size() == 1;
 		return tracks.stream()
-				.flatMap(this::disassemble)
+				.flatMap(track -> disassemble(track, tracks.indexOf(track)))
 				.skip(shouldSkipFirstPlayerTag ? 1 : 0);
 	}
 
-	private Stream<VisitableSongElement> disassemble(SongTrack track) {
+	private Stream<VisitableSongElement> disassemble(SongTrack track, int trackIndex) {
 		return Stream.concat(
-				Stream.of(new TrackElement(track.getPlayer())),
+				Stream.of(new TrackElement(trackIndex + 1)),
 				disassembleLines(track.getLines())
 		);
 	}

--- a/src/test/java/com/github/nianna/karedi/txt/saver/SongDisassemblerTest.java
+++ b/src/test/java/com/github/nianna/karedi/txt/saver/SongDisassemblerTest.java
@@ -47,7 +47,7 @@ public class SongDisassemblerTest {
     @Test
     public void shouldDisassembleDuetSong() {
         List<Tag> tags = List.of(new Tag("foo", "bar"), new Tag("foo2", "bar2"));
-        List<SongTrack> songTracks = List.of(createSongTrack(1), createSongTrack(2));
+        List<SongTrack> songTracks = List.of(createSongTrack(1), createSongTrack(3));
 
         List<VisitableSongElement> result = songDisassembler.disassemble(tags, songTracks);
 


### PR DESCRIPTION
If current song has e.g. 3 tracks and user wants to export tracks no 2 and 3, then they will become tracks number 1 and 2 in the new file. Multiplayer name tags must be adjusted accordingly.