### PR TITLE
Add warn if DUETSINGERP tag used not for duet song

### DIFF
--- a/src/main/java/com/github/nianna/karedi/problem/DuetTagNotForDuetProblem.java
+++ b/src/main/java/com/github/nianna/karedi/problem/DuetTagNotForDuetProblem.java
@@ -1,0 +1,11 @@
+package com.github.nianna.karedi.problem;
+
+import com.github.nianna.karedi.I18N;
+
+public class DuetTagNotForDuetProblem extends TagProblem {
+
+    public DuetTagNotForDuetProblem(String key) {
+        super(Severity.WARNING, I18N.get("problem.tag.duet_not_for_duet.title", key), key);
+    }
+
+}

--- a/src/main/java/com/github/nianna/karedi/song/SongChecker.java
+++ b/src/main/java/com/github/nianna/karedi/song/SongChecker.java
@@ -1,5 +1,6 @@
 package com.github.nianna.karedi.song;
 
+import com.github.nianna.karedi.problem.DuetTagNotForDuetProblem;
 import com.github.nianna.karedi.problem.InvalidMedleyBeatRangeProblem;
 import com.github.nianna.karedi.problem.InvalidMedleyLengthProblem;
 import com.github.nianna.karedi.problem.MedleyMissingProblem;
@@ -113,6 +114,15 @@ public class SongChecker implements Problematic {
 					.ifPresent(ignored -> combiner.add(new TagForNonexistentTrackProblem(tagKey)));
 		}
 
+		if (isADuetSingerTagForExistingTrackInNotDuetSong(tagKey)) {
+			combiner.add(new DuetTagNotForDuetProblem(tagKey));
+		}
+
+	}
+
+	private boolean isADuetSingerTagForExistingTrackInNotDuetSong(String tagKey) {
+		return TagKey.isKey(tagKey, TagKey.DUETSINGERP1) && song.getTrackCount() != 2
+				|| TagKey.isKey(tagKey, TagKey.DUETSINGERP2) && song.getTrackCount() > 2;
 	}
 
 	private void performAdditionalValueValidation(TagKey key) {

--- a/src/main/java/com/github/nianna/karedi/song/tag/MultiplayerTags.java
+++ b/src/main/java/com/github/nianna/karedi/song/tag/MultiplayerTags.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 
 public final class MultiplayerTags {
 
-	private static final Pattern MULTIPLAYER_TAG_NAME_PATTERN = Pattern.compile("(DUETSINGERP|P)(\\d+)");
+	private static final Pattern TAG_KEY_PATTERN = Pattern.compile("DUETSINGERP([12])|P([1-9]\\d*)");
 
 	private MultiplayerTags() {
 	}
@@ -19,7 +19,7 @@ public final class MultiplayerTags {
 	}
 
 	public static boolean isANameTagKey(String tagKey) {
-		return MULTIPLAYER_TAG_NAME_PATTERN.matcher(tagKey).matches();
+		return TAG_KEY_PATTERN.matcher(tagKey).matches();
 	}
 
 	public static String getTagKeyForTrackNumber(int index, FormatSpecification formatSpecification) {
@@ -39,9 +39,10 @@ public final class MultiplayerTags {
 	}
 
 	private static Optional<Integer> getPlayerNumber(String tagKey) {
-		Matcher matcher = MULTIPLAYER_TAG_NAME_PATTERN.matcher(tagKey);
+		Matcher matcher = TAG_KEY_PATTERN.matcher(tagKey);
 		if (matcher.find()) {
-			return Converter.toInteger(matcher.group(2));
+			String playerNumber = Optional.ofNullable(matcher.group(1)).orElseGet(() -> matcher.group(2));
+			return Converter.toInteger(playerNumber);
 		}
 		return Optional.empty();
 	}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -350,6 +350,7 @@ problem.tag.validation_fail.title=Tag validation failed
 problem.tag.validation_fail.full_title=Tag validation failed #{0}
 problem.tag.unsupported.title=Unsupported tag #{0}
 problem.tag.nonexistent_track.title=Tag #{0} defines name for nonexistent track
+problem.tag.duet_not_for_duet.title=Tag #{0} defined not for duet song
 problem.tag.inconsistent.title=Tags #{0} and #{1} are inconsistent
 problem.tag.inconsistent.description=These tags have the same meaning, remove one of them or use the same value
 problem.uncommon_golden_bonus.title=Uncommon golden bonus

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -350,6 +350,7 @@ problem.tag.validation_fail.title=Tag validation failed
 problem.tag.validation_fail.full_title=Tag validation failed #{0}
 problem.tag.unsupported.title=Unsupported tag #{0}
 problem.tag.nonexistent_track.title=Tag #{0} defines name for nonexistent track
+problem.tag.duet_not_for_duet.title=Tag #{0} defined not for duet song
 problem.tag.inconsistent.title=Tags #{0} and #{1} are inconsistent
 problem.tag.inconsistent.description=These tags have the same meaning, remove one of them or use the same value
 problem.uncommon_golden_bonus.title=Uncommon golden bonus

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -360,6 +360,7 @@ problem.tag.inconsistent.title=Tagi #{0} i #{1} s\u0105 niespójne
 problem.tag.inconsistent.description=Te tagi maj\u0105 t\u0105 sam\u0105 funkcj\u0119, usu\u0144 jeden z nich lub ustaw t\u0105 sam\u0105 warto\u015B\u0107
 problem.tag.unsupported.title=Niewspierany tag #{0}
 problem.tag.nonexistent_track.title=Tag #{0} definiuje nazw\u0119 dla nieistniej\u0105cej \u015Bcie\u017Cki
+problem.tag.duet_not_for_duet.title=Tag #{0} u\u017Cyty nie w duecie
 problem.uncommon_golden_bonus.title=Niepoprawny bonus za z\u0142ote nuty
 problem.uncommon_golden_bonus.full_title=Niepoprawny bonus za z\u0142ote nuty ({0, number} punktów)
 problem.uncommon_golden_bonus.description=Z\u0142ote nuty powinny by\u0107 warte od {0, number, integer} do {1, number, integer} punktów

--- a/src/test/java/com/github/nianna/karedi/song/tag/MultiplayerTagsTest.java
+++ b/src/test/java/com/github/nianna/karedi/song/tag/MultiplayerTagsTest.java
@@ -16,10 +16,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class MultiplayerTagsTest {
 
 	@ParameterizedTest
-	@ValueSource(strings = {"DUETSINGERP1", "DUETSINGERP2", "P1", "P2", "P3"})
+	@ValueSource(strings = {"DUETSINGERP1", "DUETSINGERP2", "P1", "P20", "P9"})
 	public void recognizesValidNameTagKeys(String key) {
 		Tag tag = new Tag(key, "");
 		assertTrue(MultiplayerTags.isANameTag(tag));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"DUETSINGERP0", "DUETSINGERP3", "P0", "P02"})
+	public void doesNotRecognizeInvalidNameTags(String key) {
+		Tag tag = new Tag(key, "");
+		assertFalse(MultiplayerTags.isANameTag(tag));
 	}
 
 	@Test
@@ -30,10 +37,10 @@ public class MultiplayerTagsTest {
 
 	@Test
 	public void extractsCorrectTrackNumbersFromValidDuetSingerPTags() {
-		Tag tag = new Tag("DUETSINGERP3", "");
+		Tag tag = new Tag("DUETSINGERP2", "");
 		Optional<Integer> result = MultiplayerTags.getTrackNumber(tag);
 		assertTrue(result.isPresent());
-		assertEquals((Integer) 2, result.get());
+		assertEquals((Integer) 1, result.get());
 	}
 
 	@Test


### PR DESCRIPTION
Add error if DUETSINGERP tags are used in not duets.
Excluding case where DUETSINGERP2 is used in 1 track song, because in such case TagForNonexistentTrackProblem will be added instead for this tag.

Recognize only DUETSINGERP1, DUETSINGERP2 and P1, P2... tags as multiplayer tags.