### PR TITLE
Feat/choose format version in new song wizard

### DIFF
--- a/src/main/java/com/github/nianna/karedi/Settings.java
+++ b/src/main/java/com/github/nianna/karedi/Settings.java
@@ -1,5 +1,6 @@
 package com.github.nianna.karedi;
 
+import com.github.nianna.karedi.song.tag.FormatSpecification;
 import com.github.nianna.karedi.util.ColorUtils;
 import javafx.scene.paint.Color;
 
@@ -35,6 +36,8 @@ public final class Settings {
 	private static final String NEW_SONG_WIZARD_LIBRARY_DIR = "ui_new_song_wizard_library_dir";
 
 	private static final String NEW_SONG_WIZARD_TAGS_CREATOR_DEFAULT = "ui_new_song_wizard_tags_creator_default";
+
+	private static final String NEW_SONG_WIZARD_FORMAT_VERSION_DEFAULT = "ui_new_song_wizard_format_version_default";
 
 	private static final String TAGS_MULTIPLAYER_USE_DUETSINGER = "format_tags_multiplayer_use_duetsinger";
 
@@ -164,5 +167,19 @@ public final class Settings {
 
 	public static boolean isPlaceSpacesAfterWords() {
 		return PREFERENCES.getBoolean(FORMAT_PLACE_SPACE_AFTER_WORDS, false);
+	}
+
+	public static void setDefaultFormatSpecificationVersion(FormatSpecification value) {
+		if (value != null) {
+			PREFERENCES.put(NEW_SONG_WIZARD_FORMAT_VERSION_DEFAULT, value.toString());
+		} else {
+			PREFERENCES.remove(NEW_SONG_WIZARD_FORMAT_VERSION_DEFAULT);
+		}
+	}
+
+	public static Optional<FormatSpecification> getDefaultFormatSpecificationVersion() {
+		String value = PREFERENCES.get(NEW_SONG_WIZARD_FORMAT_VERSION_DEFAULT, null);
+		return Optional.ofNullable(value)
+				.flatMap(FormatSpecification::tryParse);
 	}
 }

--- a/src/main/java/com/github/nianna/karedi/context/actions/NewSongWizard.java
+++ b/src/main/java/com/github/nianna/karedi/context/actions/NewSongWizard.java
@@ -51,12 +51,9 @@ class NewSongWizard {
 			song.setTagValue(TagKey.TITLE, result.getTitle());
 			song.setTagValue(TagKey.MP3, result.getAudioFilename());
 			song.setTagValue(TagKey.COVER, result.getCoverFilename());
-			result.getBackgroundFilename().ifPresent(filename -> {
-				song.setTagValue(TagKey.BACKGROUND, filename);
-			});
-			result.getVideoFilename().ifPresent(filename -> {
-				song.setTagValue(TagKey.VIDEO, filename);
-			});
+			result.getBackgroundFilename().ifPresent(filename -> song.setTagValue(TagKey.BACKGROUND, filename));
+			result.getVideoFilename().ifPresent(filename -> song.setTagValue(TagKey.VIDEO, filename));
+			result.getFormatSpecification().ifPresent(version -> song.setTagValue(TagKey.VERSION, version.toString()));
 			return true;
 		}
 		return false;
@@ -112,10 +109,10 @@ class NewSongWizard {
 		return true;
 	}
 
-	class CreatorResult {
-		private Song song;
-		private File audioFile;
-		private File outputDir;
+	static class CreatorResult {
+		private final Song song;
+		private final File audioFile;
+		private final File outputDir;
 
 		CreatorResult(Song song, File audioFile, File outputDir) {
 			this.song = song;

--- a/src/main/java/com/github/nianna/karedi/context/actions/NewSongWizard.java
+++ b/src/main/java/com/github/nianna/karedi/context/actions/NewSongWizard.java
@@ -43,6 +43,8 @@ class NewSongWizard {
 				.map(File::getName)
 				.ifPresent(dialog::initDataFromAudioFilename);
 		dialog.setTitle(I18N.get("dialog.creator.title"));
+		dialog.hideInstrumental();
+		dialog.hideVocals();
 		Optional<FilenamesEditResult> optResult = dialog.showAndWait();
 		if (optResult.isPresent()) {
 			FilenamesEditResult result = optResult.get();
@@ -56,6 +58,8 @@ class NewSongWizard {
 			song.setTagValue(TagKey.COVER, result.getCoverFilename());
 			result.getBackgroundFilename().ifPresent(filename -> song.setTagValue(TagKey.BACKGROUND, filename));
 			result.getVideoFilename().ifPresent(filename -> song.setTagValue(TagKey.VIDEO, filename));
+			result.getInstrumentalFilename().ifPresent(filename -> song.setTagValue(TagKey.INSTRUMENTAL, filename));
+			result.getVocalsFilename().ifPresent(filename -> song.setTagValue(TagKey.VOCALS, filename));
 			return true;
 		}
 		return false;

--- a/src/main/java/com/github/nianna/karedi/context/actions/NewSongWizard.java
+++ b/src/main/java/com/github/nianna/karedi/context/actions/NewSongWizard.java
@@ -45,6 +45,7 @@ class NewSongWizard {
 		dialog.setTitle(I18N.get("dialog.creator.title"));
 		dialog.hideInstrumental();
 		dialog.hideVocals();
+		Settings.getDefaultFormatSpecificationVersion().ifPresent(dialog::setFormatVersion);
 		Optional<FilenamesEditResult> optResult = dialog.showAndWait();
 		if (optResult.isPresent()) {
 			FilenamesEditResult result = optResult.get();
@@ -60,6 +61,8 @@ class NewSongWizard {
 			result.getVideoFilename().ifPresent(filename -> song.setTagValue(TagKey.VIDEO, filename));
 			result.getInstrumentalFilename().ifPresent(filename -> song.setTagValue(TagKey.INSTRUMENTAL, filename));
 			result.getVocalsFilename().ifPresent(filename -> song.setTagValue(TagKey.VOCALS, filename));
+
+			Settings.setDefaultFormatSpecificationVersion(result.getFormatSpecification().orElse(null));
 			return true;
 		}
 		return false;

--- a/src/main/java/com/github/nianna/karedi/context/actions/NewSongWizard.java
+++ b/src/main/java/com/github/nianna/karedi/context/actions/NewSongWizard.java
@@ -47,13 +47,15 @@ class NewSongWizard {
 		if (optResult.isPresent()) {
 			FilenamesEditResult result = optResult.get();
 			song = new Song();
+			result.getFormatSpecification().ifPresent(version -> song.setTagValue(TagKey.VERSION, version.toString()));
 			song.setTagValue(TagKey.ARTIST, result.getArtist());
 			song.setTagValue(TagKey.TITLE, result.getTitle());
+			song.formatSpecificationVersion()
+					.ifPresent(ignored -> song.setTagValue(TagKey.AUDIO, result.getAudioFilename()));
 			song.setTagValue(TagKey.MP3, result.getAudioFilename());
 			song.setTagValue(TagKey.COVER, result.getCoverFilename());
 			result.getBackgroundFilename().ifPresent(filename -> song.setTagValue(TagKey.BACKGROUND, filename));
 			result.getVideoFilename().ifPresent(filename -> song.setTagValue(TagKey.VIDEO, filename));
-			result.getFormatSpecification().ifPresent(version -> song.setTagValue(TagKey.VERSION, version.toString()));
 			return true;
 		}
 		return false;

--- a/src/main/java/com/github/nianna/karedi/context/actions/RenameAction.java
+++ b/src/main/java/com/github/nianna/karedi/context/actions/RenameAction.java
@@ -6,6 +6,7 @@ import com.github.nianna.karedi.command.CommandComposite;
 import com.github.nianna.karedi.command.tag.ChangeTagValueCommand;
 import com.github.nianna.karedi.context.AppContext;
 import com.github.nianna.karedi.dialog.EditFilenamesDialog;
+import com.github.nianna.karedi.song.Song;
 import com.github.nianna.karedi.song.tag.TagKey;
 import javafx.event.ActionEvent;
 
@@ -51,18 +52,22 @@ class RenameAction extends ContextfulKarediAction {
 
             @Override
             protected void buildSubCommands() {
-                addSubCommand(new ChangeTagValueCommand(activeSongContext.getSong(), TagKey.ARTIST,
+                Song song = activeSongContext.getSong();
+                addSubCommand(new ChangeTagValueCommand(song, TagKey.ARTIST,
                         result.getArtist()));
-                addSubCommand(new ChangeTagValueCommand(activeSongContext.getSong(), TagKey.TITLE, result.getTitle()));
-                addSubCommand(new ChangeTagValueCommand(activeSongContext.getSong(), TagKey.MP3, result.getAudioFilename()));
-                addSubCommand(new ChangeTagValueCommand(activeSongContext.getSong(), TagKey.COVER, result.getCoverFilename()));
+                addSubCommand(new ChangeTagValueCommand(song, TagKey.TITLE, result.getTitle()));
+                addSubCommand(new ChangeTagValueCommand(song, TagKey.MP3, result.getAudioFilename()));
+                if (song.hasTag(TagKey.AUDIO) || song.formatSpecificationVersion().isPresent()) {
+                    addSubCommand(new ChangeTagValueCommand(song, TagKey.AUDIO, result.getAudioFilename()));
+                }
+                addSubCommand(new ChangeTagValueCommand(song, TagKey.COVER, result.getCoverFilename()));
                 result.getBackgroundFilename()
                         .ifPresent(filename -> addSubCommand(
-                                new ChangeTagValueCommand(activeSongContext.getSong(), TagKey.BACKGROUND, filename))
+                                new ChangeTagValueCommand(song, TagKey.BACKGROUND, filename))
                         );
                 result.getVideoFilename()
                         .ifPresent(filename -> addSubCommand(
-                                new ChangeTagValueCommand(activeSongContext.getSong(), TagKey.VIDEO, filename))
+                                new ChangeTagValueCommand(song, TagKey.VIDEO, filename))
                         );
             }
         };

--- a/src/main/java/com/github/nianna/karedi/context/actions/RenameAction.java
+++ b/src/main/java/com/github/nianna/karedi/context/actions/RenameAction.java
@@ -38,6 +38,8 @@ class RenameAction extends ContextfulKarediAction {
         activeSongContext.getSong().getTagValue(TagKey.VOCALS)
                 .ifPresentOrElse(dialog::setVocalsFilename, dialog::hideVocals);
 
+        activeSongContext.getSong().formatSpecificationVersion().ifPresent(dialog::setFormatVersion);
+
         Optional<EditFilenamesDialog.FilenamesEditResult> optionalResult = dialog.showAndWait();
         optionalResult.ifPresent(result -> executeCommand(commandFromResults(result)));
     }

--- a/src/main/java/com/github/nianna/karedi/context/actions/RenameAction.java
+++ b/src/main/java/com/github/nianna/karedi/context/actions/RenameAction.java
@@ -21,6 +21,7 @@ class RenameAction extends ContextfulKarediAction {
     @Override
     protected void onAction(ActionEvent event) {
         EditFilenamesDialog dialog = new EditFilenamesDialog();
+        dialog.hideFormatSpecificationChoiceBox();
 
         activeSongContext.getSong().getTagValue(TagKey.ARTIST).ifPresent(dialog::setSongArtist);
         activeSongContext.getSong().getTagValue(TagKey.TITLE).ifPresent(dialog::setSongTitle);

--- a/src/main/java/com/github/nianna/karedi/context/actions/RenameAction.java
+++ b/src/main/java/com/github/nianna/karedi/context/actions/RenameAction.java
@@ -29,19 +29,14 @@ class RenameAction extends ContextfulKarediAction {
         activeSongContext.getSong().getMainAudioTagValue().ifPresent(dialog::setAudioFilename);
         activeSongContext.getSong().getTagValue(TagKey.COVER).ifPresent(dialog::setCoverFilename);
 
-        Optional<String> optVideoFilename = activeSongContext.getSong().getTagValue(TagKey.VIDEO);
-        if (optVideoFilename.isPresent()) {
-            dialog.setVideoFilename(optVideoFilename.get());
-        } else {
-            dialog.hideVideo();
-        }
-
-        Optional<String> optBackgroundFilename = activeSongContext.getSong().getTagValue(TagKey.BACKGROUND);
-        if (optBackgroundFilename.isPresent()) {
-            dialog.setBackgroundFilename(optBackgroundFilename.get());
-        } else {
-            dialog.hideBackground();
-        }
+        activeSongContext.getSong().getTagValue(TagKey.VIDEO)
+                .ifPresentOrElse(dialog::setVideoFilename, dialog::hideVideo);
+        activeSongContext.getSong().getTagValue(TagKey.BACKGROUND)
+                .ifPresentOrElse(dialog::setBackgroundFilename, dialog::hideBackground);
+        activeSongContext.getSong().getTagValue(TagKey.INSTRUMENTAL)
+                .ifPresentOrElse(dialog::setInstrumentalFilename, dialog::hideInstrumental);
+        activeSongContext.getSong().getTagValue(TagKey.VOCALS)
+                .ifPresentOrElse(dialog::setVocalsFilename, dialog::hideVocals);
 
         Optional<EditFilenamesDialog.FilenamesEditResult> optionalResult = dialog.showAndWait();
         optionalResult.ifPresent(result -> executeCommand(commandFromResults(result)));
@@ -69,6 +64,12 @@ class RenameAction extends ContextfulKarediAction {
                         .ifPresent(filename -> addSubCommand(
                                 new ChangeTagValueCommand(song, TagKey.VIDEO, filename))
                         );
+                result.getInstrumentalFilename()
+                        .ifPresent(filename -> addSubCommand(
+                                new ChangeTagValueCommand(song, TagKey.INSTRUMENTAL, filename))
+                        );
+                result.getVocalsFilename()
+                        .ifPresent(filename -> addSubCommand(new ChangeTagValueCommand(song, TagKey.VOCALS, filename)));
             }
         };
     }

--- a/src/main/java/com/github/nianna/karedi/dialog/EditFilenamesDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/EditFilenamesDialog.java
@@ -43,7 +43,9 @@ public class EditFilenamesDialog extends ValidatedDialog<FilenamesEditResult> {
 	private static final String DEFAULT_VIDEO_EXTENSION = "mp4";
 
 	@FXML
-	private ManageableGridPane gridPane;
+	private ManageableGridPane artistTitleGridPane;
+	@FXML
+	private ManageableGridPane filenamesGridPane;
 
 	@FXML
 	private TextField artistField;
@@ -150,9 +152,9 @@ public class EditFilenamesDialog extends ValidatedDialog<FilenamesEditResult> {
 	}
 
 	public void hideFormatSpecificationChoiceBox() {
-		int formatChoiceBoxRowIndex = gridPane.getChildRowIndex(formatSpecificationChoiceBox);
-		gridPane.changeRowVisibility(formatChoiceBoxRowIndex, false);
-		gridPane.changeRowVisibility(formatChoiceBoxRowIndex - 1, false);
+		int formatChoiceBoxRowIndex = artistTitleGridPane.getChildRowIndex(formatSpecificationChoiceBox);
+		artistTitleGridPane.changeRowVisibility(formatChoiceBoxRowIndex, false);
+		artistTitleGridPane.changeRowVisibility(formatChoiceBoxRowIndex - 1, false);
 	}
 
 	private static ObservableList<String> supportedFormatSpecificationVersions() {
@@ -244,13 +246,13 @@ public class EditFilenamesDialog extends ValidatedDialog<FilenamesEditResult> {
 	}
 
 	private void onIncludeVideoInvalidated(Observable obs) {
-		gridPane.changeRowVisibility(gridPane.getChildRowIndex(videoField),
+		filenamesGridPane.changeRowVisibility(filenamesGridPane.getChildRowIndex(videoField),
 				includeVideoCheckBox.isSelected());
 	}
 
 	private void onIncludeBackgroundInvalidated(Observable obs) {
 		boolean isSelected = includeBackgroundCheckBox.isSelected();
-		gridPane.changeRowVisibility(gridPane.getChildRowIndex(backgroundField), isSelected);
+		filenamesGridPane.changeRowVisibility(filenamesGridPane.getChildRowIndex(backgroundField), isSelected);
 		addCoCheckBox.setDisable(isSelected);
 		if (isSelected) {
 			addCoCheckBox.setSelected(true);

--- a/src/main/java/com/github/nianna/karedi/dialog/EditFilenamesDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/EditFilenamesDialog.java
@@ -5,6 +5,7 @@ import com.github.nianna.karedi.context.AudioContext;
 import com.github.nianna.karedi.control.ManageableGridPane;
 import com.github.nianna.karedi.control.RestrictedTextField;
 import com.github.nianna.karedi.dialog.EditFilenamesDialog.FilenamesEditResult;
+import com.github.nianna.karedi.song.tag.FormatSpecification;
 import com.github.nianna.karedi.song.tag.TagKey;
 import com.github.nianna.karedi.song.tag.TagValueValidators;
 import com.github.nianna.karedi.util.Utils;
@@ -12,11 +13,14 @@ import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.binding.Bindings;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.CheckBox;
+import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextField;
 import javafx.scene.input.MouseEvent;
@@ -24,6 +28,7 @@ import javafx.scene.paint.Color;
 import javafx.util.Pair;
 import org.controlsfx.glyphfont.Glyph;
 
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -82,6 +87,8 @@ public class EditFilenamesDialog extends ValidatedDialog<FilenamesEditResult> {
 	private TextField backgroundField;
 	@FXML
 	private TextField backgroundExtensionField;
+	@FXML
+	private ChoiceBox<String> formatSpecificationChoiceBox;
 
 	private boolean hideVideo = false;
 	private boolean hideBackground = false;
@@ -128,6 +135,9 @@ public class EditFilenamesDialog extends ValidatedDialog<FilenamesEditResult> {
 		coverExtensionField.setText(DEFAULT_IMAGE_EXTENSION);
 		backgroundExtensionField.setText(DEFAULT_IMAGE_EXTENSION);
 
+		formatSpecificationChoiceBox.setItems(supportedFormatSpecificationVersions());
+		formatSpecificationChoiceBox.getSelectionModel().selectFirst();
+
 		Platform.runLater(() -> {
 			validationSupport.registerValidator(titleField, TagValueValidators.forKey(TagKey.TITLE));
 			validationSupport.registerValidator(artistField, TagValueValidators.forKey(TagKey.ARTIST));
@@ -136,6 +146,19 @@ public class EditFilenamesDialog extends ValidatedDialog<FilenamesEditResult> {
 			includeBackgroundCheckBox.setSelected(!hideBackground);
 			includeVideoCheckBox.setSelected(!hideVideo);
 		});
+	}
+
+	public void hideFormatSpecificationChoiceBox() {
+		int formatChoiceBoxRowIndex = gridPane.getChildRowIndex(formatSpecificationChoiceBox);
+		gridPane.changeRowVisibility(formatChoiceBoxRowIndex, false);
+		gridPane.changeRowVisibility(formatChoiceBoxRowIndex - 1, false);
+	}
+
+	private static ObservableList<String> supportedFormatSpecificationVersions() {
+		ObservableList<String> formatSpecifications = FXCollections
+				.observableArrayList("None");
+		Arrays.stream(FormatSpecification.values()).map(Enum::toString).forEach(formatSpecifications::add);
+		return formatSpecifications;
 	}
 
 	public void initDataFromAudioFilename(String audioFileName) {
@@ -330,6 +353,7 @@ public class EditFilenamesDialog extends ValidatedDialog<FilenamesEditResult> {
 		private String coverFilename;
 		private String backgroundFilename;
 		private String videoFilename;
+		private FormatSpecification formatSpecification;
 
 		private FilenamesEditResult() {
 			super();
@@ -345,6 +369,9 @@ public class EditFilenamesDialog extends ValidatedDialog<FilenamesEditResult> {
 				videoFilename = generateFilename(videoField.getText(),
 						videoExtensionField.getText());
 			}
+			formatSpecification = FormatSpecification
+					.tryParse(formatSpecificationChoiceBox.getSelectionModel().getSelectedItem())
+					.orElse(null);
 		}
 
 		private String generateFilename(String name, String extension) {
@@ -373,6 +400,10 @@ public class EditFilenamesDialog extends ValidatedDialog<FilenamesEditResult> {
 
 		public Optional<String> getVideoFilename() {
 			return Optional.ofNullable(videoFilename);
+		}
+
+		public Optional<FormatSpecification> getFormatSpecification() {
+			return Optional.ofNullable(formatSpecification);
 		}
 
 	}

--- a/src/main/java/com/github/nianna/karedi/dialog/EditFilenamesDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/EditFilenamesDialog.java
@@ -161,7 +161,6 @@ public class EditFilenamesDialog extends ValidatedDialog<FilenamesEditResult> {
 				this::onIncludeInstrumentalInvalidated);
 		addAndExecuteInvalidationListener(includeVocalsCheckBox.selectedProperty(),
 				this::onIncludeVocalsInvalidated);
-
 		addAndExecuteInvalidationListener(addCoCheckBox.selectedProperty(),
 				this::onAddCoCheckBoxInvalidated);
 
@@ -178,6 +177,8 @@ public class EditFilenamesDialog extends ValidatedDialog<FilenamesEditResult> {
 
 		formatSpecificationChoiceBox.setItems(supportedFormatSpecificationVersions());
 		formatSpecificationChoiceBox.getSelectionModel().selectFirst();
+		formatSpecificationChoiceBox.getSelectionModel().selectedItemProperty()
+				.addListener(this::onSelectedFormatSpecificationInvalidated);
 
 		Platform.runLater(() -> {
 			validationSupport.registerValidator(titleField, TagValueValidators.forKey(TagKey.TITLE));
@@ -329,7 +330,23 @@ public class EditFilenamesDialog extends ValidatedDialog<FilenamesEditResult> {
 				}
 			}
 		}
+	}
 
+	private void onSelectedFormatSpecificationInvalidated(Observable obs) {
+		FormatSpecification.tryParse(formatSpecificationChoiceBox.getSelectionModel().getSelectedItem())
+				.filter(FormatSpecification.V_1_0_0::equals)
+				.ifPresentOrElse(
+						ignored -> {
+							hideInstrumental();
+							hideVocals();
+							includeInstrumentalCheckBox.setDisable(true);
+							includeVocalsCheckBox.setDisable(true);
+						},
+						() -> {
+							includeInstrumentalCheckBox.setDisable(false);
+							includeVocalsCheckBox.setDisable(false);
+						}
+				);
 	}
 
 	private void setFilename(Glyph glyph, TextField field, TextField extensionField, String value) {
@@ -394,9 +411,13 @@ public class EditFilenamesDialog extends ValidatedDialog<FilenamesEditResult> {
 		setFilename(vocalsLinkGlyph, vocalsField, vocalsExtensionField, value);
 	}
 
+	public void setFormatVersion(FormatSpecification formatSpecification) {
+		formatSpecificationChoiceBox.getSelectionModel().select(formatSpecification.toString());
+	}
+
 	public void hideBackground() {
 		if (this.isShowing()) {
-			includeBackgroundCheckBox.setSelected(true);
+			includeBackgroundCheckBox.setSelected(false);
 		} else {
 			hideBackground = true;
 		}
@@ -404,7 +425,7 @@ public class EditFilenamesDialog extends ValidatedDialog<FilenamesEditResult> {
 
 	public void hideVideo() {
 		if (this.isShowing()) {
-			includeVideoCheckBox.setSelected(true);
+			includeVideoCheckBox.setSelected(false);
 		} else {
 			hideVideo = true;
 		}
@@ -412,7 +433,7 @@ public class EditFilenamesDialog extends ValidatedDialog<FilenamesEditResult> {
 
 	public void hideInstrumental() {
 		if (this.isShowing()) {
-			includeInstrumentalCheckBox.setSelected(true);
+			includeInstrumentalCheckBox.setSelected(false);
 		} else {
 			hideInstrumental = true;
 		}
@@ -420,7 +441,7 @@ public class EditFilenamesDialog extends ValidatedDialog<FilenamesEditResult> {
 
 	public void hideVocals() {
 		if (this.isShowing()) {
-			includeVocalsCheckBox.setSelected(true);
+			includeVocalsCheckBox.setSelected(false);
 		} else {
 			hideVocals = true;
 		}

--- a/src/main/java/com/github/nianna/karedi/dialog/EditFilenamesDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/EditFilenamesDialog.java
@@ -29,6 +29,7 @@ import javafx.util.Pair;
 import org.controlsfx.glyphfont.Glyph;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -157,7 +158,10 @@ public class EditFilenamesDialog extends ValidatedDialog<FilenamesEditResult> {
 	private static ObservableList<String> supportedFormatSpecificationVersions() {
 		ObservableList<String> formatSpecifications = FXCollections
 				.observableArrayList("None");
-		Arrays.stream(FormatSpecification.values()).map(Enum::toString).forEach(formatSpecifications::add);
+		Arrays.stream(FormatSpecification.values())
+				.map(Enum::toString)
+				.sorted(Comparator.reverseOrder())
+				.forEach(formatSpecifications::add);
 		return formatSpecifications;
 	}
 

--- a/src/main/resources/fxml/EditFilenamesDialogPaneLayout.fxml
+++ b/src/main/resources/fxml/EditFilenamesDialogPaneLayout.fxml
@@ -18,7 +18,7 @@
 <?import org.controlsfx.glyphfont.Glyph?>
 
 <fx:root type="javafx.scene.control.DialogPane" xmlns="http://javafx.com/javafx/8.0.60"
-		 xmlns:fx="http://javafx.com/fxml/1">
+         xmlns:fx="http://javafx.com/fxml/1">
     <content>
         <ManageableGridPane fx:id="gridPane" hgap="10.0">
             <columnConstraints>
@@ -39,6 +39,8 @@
                                 vgrow="NEVER"/>
                 <RowConstraints minHeight="10.0" prefHeight="30.0"
                                 vgrow="NEVER"/>
+                <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
+                <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
                 <RowConstraints minHeight="10.0" prefHeight="30.0"
                                 vgrow="NEVER"/>
                 <RowConstraints minHeight="10.0" prefHeight="30.0"
@@ -51,8 +53,6 @@
                                 vgrow="NEVER"/>
                 <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
                 <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
-                <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
-                <RowConstraints vgrow="NEVER"/>
             </rowConstraints>
             <padding>
                 <Insets bottom="20.0" left="20.0" right="20.0" top="20.0"/>
@@ -80,63 +80,64 @@
             <Separator prefHeight="0.0" prefWidth="162.0"
                        GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.rowIndex="4"/>
 
+            <Label text="%dialog.edit_filenames.format_ver" GridPane.columnSpan="3" GridPane.columnIndex="1"
+                   GridPane.rowIndex="5"/>
+            <ChoiceBox fx:id="formatSpecificationChoiceBox" minWidth="75" GridPane.columnSpan="2"
+                       GridPane.columnIndex="4" GridPane.rowIndex="5"/>
+
+            <Separator prefWidth="200.0" GridPane.columnIndex="1" GridPane.columnSpan="5" GridPane.rowIndex="6"/>
+
             <CheckBox fx:id="includeVideoCheckBox" mnemonicParsing="false"
                       selected="true" text="%common.video" GridPane.columnIndex="1"
-                      GridPane.rowIndex="5"/>
+                      GridPane.rowIndex="7"/>
             <CheckBox fx:id="includeBackgroundCheckBox"
                       mnemonicParsing="false" selected="true" text="%common.background"
-                      GridPane.columnIndex="2" GridPane.rowIndex="5"/>
+                      GridPane.columnIndex="2" GridPane.rowIndex="7"/>
 
             <Separator prefWidth="200.0" GridPane.columnIndex="1"
-                       GridPane.columnSpan="5" GridPane.rowIndex="6"/>
+                       GridPane.columnSpan="5" GridPane.rowIndex="8"/>
 
             <Glyph fx:id="audioLinkGlyph" fontFamily="FontAwesome" icon="LINK"
-                   GridPane.rowIndex="7"/>
-            <Label text="%dialog.edit_filenames.audio"
-                   GridPane.columnIndex="1" GridPane.rowIndex="7"/>
-            <FilenameTextField fx:id="audioField"
-                               GridPane.columnIndex="2" GridPane.rowIndex="7"/>
-            <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="7"/>
-            <ComboBox fx:id="audioExtensionField"
-                      GridPane.columnIndex="4" GridPane.rowIndex="7"/>
-
-            <Glyph fx:id="coverLinkGlyph" fontFamily="FontAwesome" icon="LINK"
-                   GridPane.rowIndex="8"/>
-            <Label text="%dialog.edit_filenames.cover"
-                   GridPane.columnIndex="1" GridPane.rowIndex="8"/>
-            <FilenameTextField fx:id="coverField"
-                               GridPane.columnIndex="2" GridPane.rowIndex="8"/>
-            <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="8"/>
-            <TextField fx:id="coverExtensionField"
-                       GridPane.columnIndex="4" GridPane.rowIndex="8"/>
-            <CheckBox fx:id="addCoCheckBox" mnemonicParsing="false"
-                      selected="true" text="[CO]" GridPane.columnIndex="5"
-                      GridPane.rowIndex="8"/>
-
-            <Glyph fx:id="videoLinkGlyph" fontFamily="FontAwesome" icon="LINK"
                    GridPane.rowIndex="9"/>
-            <Label fx:id="videoLabel" text="%dialog.edit_filenames.video"
+            <Label text="%dialog.edit_filenames.audio"
                    GridPane.columnIndex="1" GridPane.rowIndex="9"/>
-            <FilenameTextField fx:id="videoField"
+            <FilenameTextField fx:id="audioField"
                                GridPane.columnIndex="2" GridPane.rowIndex="9"/>
             <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="9"/>
-            <TextField fx:id="videoExtensionField"
-                       GridPane.columnIndex="4" GridPane.rowIndex="9"/>
+            <ComboBox fx:id="audioExtensionField"
+                      GridPane.columnIndex="4" GridPane.rowIndex="9"/>
 
-            <Glyph fx:id="backgroundLinkGlyph" fontFamily="FontAwesome"
-                   icon="LINK" GridPane.rowIndex="10"/>
-            <Label fx:id="backgroundLabel" text="%dialog.edit_filenames.background"
+            <Glyph fx:id="coverLinkGlyph" fontFamily="FontAwesome" icon="LINK"
+                   GridPane.rowIndex="10"/>
+            <Label text="%dialog.edit_filenames.cover"
                    GridPane.columnIndex="1" GridPane.rowIndex="10"/>
-            <FilenameTextField fx:id="backgroundField"
+            <FilenameTextField fx:id="coverField"
                                GridPane.columnIndex="2" GridPane.rowIndex="10"/>
             <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="10"/>
-            <TextField fx:id="backgroundExtensionField"
+            <TextField fx:id="coverExtensionField"
                        GridPane.columnIndex="4" GridPane.rowIndex="10"/>
-            <Separator prefWidth="200.0" GridPane.columnIndex="1"
-                       GridPane.columnSpan="5" GridPane.rowIndex="11"/>
-            <Label text="%dialog.edit_filenames.format_ver" GridPane.columnSpan="3"
+            <CheckBox fx:id="addCoCheckBox" mnemonicParsing="false" selected="true" text="[CO]"
+                      GridPane.columnIndex="5" GridPane.rowIndex="10"/>
+
+            <Glyph fx:id="videoLinkGlyph" fontFamily="FontAwesome" icon="LINK"
+                   GridPane.rowIndex="11"/>
+            <Label fx:id="videoLabel" text="%dialog.edit_filenames.video"
+                   GridPane.columnIndex="1" GridPane.rowIndex="11"/>
+            <FilenameTextField fx:id="videoField"
+                               GridPane.columnIndex="2" GridPane.rowIndex="11"/>
+            <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="11"/>
+            <TextField fx:id="videoExtensionField"
+                       GridPane.columnIndex="4" GridPane.rowIndex="11"/>
+
+            <Glyph fx:id="backgroundLinkGlyph" fontFamily="FontAwesome"
+                   icon="LINK" GridPane.rowIndex="12"/>
+            <Label fx:id="backgroundLabel" text="%dialog.edit_filenames.background"
                    GridPane.columnIndex="1" GridPane.rowIndex="12"/>
-            <ChoiceBox fx:id="formatSpecificationChoiceBox" minWidth="75" GridPane.columnSpan="2" GridPane.columnIndex="4" GridPane.rowIndex="12" />
+            <FilenameTextField fx:id="backgroundField"
+                               GridPane.columnIndex="2" GridPane.rowIndex="12"/>
+            <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="12"/>
+            <TextField fx:id="backgroundExtensionField"
+                       GridPane.columnIndex="4" GridPane.rowIndex="12"/>
         </ManageableGridPane>
     </content>
 </fx:root>

--- a/src/main/resources/fxml/EditFilenamesDialogPaneLayout.fxml
+++ b/src/main/resources/fxml/EditFilenamesDialogPaneLayout.fxml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!-- <?import org.controlsfx.glyphfont.*?> -->
+
+<?import com.github.nianna.karedi.control.FilenameTextField?>
+<?import com.github.nianna.karedi.control.ManageableGridPane?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.DialogPane?>
 <?import javafx.scene.control.Label?>
@@ -10,127 +15,128 @@
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.RowConstraints?>
-<?import org.controlsfx.glyphfont.*?>
-<?import com.github.nianna.karedi.control.FilenameTextField?>
-<?import com.github.nianna.karedi.control.ManageableGridPane?>
-
-<!-- <?import org.controlsfx.glyphfont.*?> -->
+<?import org.controlsfx.glyphfont.Glyph?>
 
 <fx:root type="javafx.scene.control.DialogPane" xmlns="http://javafx.com/javafx/8.0.60"
 		 xmlns:fx="http://javafx.com/fxml/1">
-	<content>
-		<ManageableGridPane fx:id="gridPane" hgap="10.0">
-			<columnConstraints>
-				<ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
-				<ColumnConstraints hgrow="SOMETIMES" />
-				<ColumnConstraints hgrow="SOMETIMES" minWidth="10.0"
-					prefWidth="200.0" />
-				<ColumnConstraints hgrow="SOMETIMES" />
-				<ColumnConstraints hgrow="SOMETIMES" prefWidth="75.0" />
-				<ColumnConstraints />
-			</columnConstraints>
-			<rowConstraints>
-				<RowConstraints minHeight="10.0" prefHeight="30.0"
-					vgrow="NEVER" />
-				<RowConstraints minHeight="10.0" prefHeight="30.0"
-					vgrow="NEVER" />
-				<RowConstraints minHeight="10.0" prefHeight="30.0"
-					vgrow="NEVER" />
-				<RowConstraints minHeight="10.0" prefHeight="30.0"
-					vgrow="NEVER" />
-				<RowConstraints minHeight="10.0" prefHeight="30.0"
-					vgrow="NEVER" />
-				<RowConstraints minHeight="10.0" prefHeight="30.0"
-					vgrow="NEVER" />
-				<RowConstraints minHeight="10.0" prefHeight="30.0"
-					vgrow="NEVER" />
-				<RowConstraints minHeight="10.0" prefHeight="30.0"
-					vgrow="NEVER" />
-				<RowConstraints minHeight="10.0" prefHeight="30.0"
-					vgrow="NEVER" />
-				<RowConstraints prefHeight="30.0" vgrow="NEVER" />
-				<RowConstraints prefHeight="30.0" vgrow="NEVER" />
-			</rowConstraints>
-			<children>
-				<Label text="%dialog.edit_filenames.artist"
-					GridPane.columnIndex="1" />
-				<TextField fx:id="artistField" promptText="%common.artist"
-					GridPane.columnIndex="2" />
+    <content>
+        <ManageableGridPane fx:id="gridPane" hgap="10.0">
+            <columnConstraints>
+                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0"/>
+                <ColumnConstraints hgrow="SOMETIMES"/>
+                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0"
+                                   prefWidth="200.0"/>
+                <ColumnConstraints hgrow="SOMETIMES"/>
+                <ColumnConstraints hgrow="SOMETIMES" prefWidth="75.0"/>
+                <ColumnConstraints/>
+            </columnConstraints>
+            <rowConstraints>
+                <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                vgrow="NEVER"/>
+                <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                vgrow="NEVER"/>
+                <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                vgrow="NEVER"/>
+                <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                vgrow="NEVER"/>
+                <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                vgrow="NEVER"/>
+                <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                vgrow="NEVER"/>
+                <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                vgrow="NEVER"/>
+                <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                vgrow="NEVER"/>
+                <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                vgrow="NEVER"/>
+                <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
+                <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
+                <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
+                <RowConstraints vgrow="NEVER"/>
+            </rowConstraints>
+            <padding>
+                <Insets bottom="20.0" left="20.0" right="20.0" top="20.0"/>
+            </padding>
+            <Label text="%dialog.edit_filenames.artist"
+                   GridPane.columnIndex="1"/>
+            <TextField fx:id="artistField" promptText="%common.artist"
+                       GridPane.columnIndex="2"/>
 
-				<Label text="%dialog.edit_filenames.title"
-					GridPane.columnIndex="1" GridPane.rowIndex="1" />
-				<TextField fx:id="titleField" promptText="%common.title"
-					GridPane.columnIndex="2" GridPane.rowIndex="1" />
+            <Label text="%dialog.edit_filenames.title"
+                   GridPane.columnIndex="1" GridPane.rowIndex="1"/>
+            <TextField fx:id="titleField" promptText="%common.title"
+                       GridPane.columnIndex="2" GridPane.rowIndex="1"/>
 
-				<Separator prefHeight="5.0" prefWidth="151.0"
-					GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.rowIndex="2" />
+            <Separator prefHeight="5.0" prefWidth="151.0"
+                       GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.rowIndex="2"/>
 
-				<Glyph fx:id="filenameLinkGlyph" fontFamily="FontAwesome"
-					icon="LINK" GridPane.rowIndex="3" />
-				<Label text="%dialog.edit_filenames.filename"
-					GridPane.columnIndex="1" GridPane.rowIndex="3" />
-				<FilenameTextField fx:id="filenameField"
-					GridPane.columnIndex="2" GridPane.rowIndex="3" />
+            <Glyph fx:id="filenameLinkGlyph" fontFamily="FontAwesome"
+                   icon="LINK" GridPane.rowIndex="3"/>
+            <Label text="%dialog.edit_filenames.filename"
+                   GridPane.columnIndex="1" GridPane.rowIndex="3"/>
+            <FilenameTextField fx:id="filenameField"
+                               GridPane.columnIndex="2" GridPane.rowIndex="3"/>
 
-				<Separator prefHeight="0.0" prefWidth="162.0"
-					GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.rowIndex="4" />
+            <Separator prefHeight="0.0" prefWidth="162.0"
+                       GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.rowIndex="4"/>
 
-				<CheckBox fx:id="includeVideoCheckBox" mnemonicParsing="false"
-					selected="true" text="%common.video" GridPane.columnIndex="1"
-					GridPane.rowIndex="5" />
-				<CheckBox fx:id="includeBackgroundCheckBox"
-					mnemonicParsing="false" selected="true" text="%common.background"
-					GridPane.columnIndex="2" GridPane.rowIndex="5" />
+            <CheckBox fx:id="includeVideoCheckBox" mnemonicParsing="false"
+                      selected="true" text="%common.video" GridPane.columnIndex="1"
+                      GridPane.rowIndex="5"/>
+            <CheckBox fx:id="includeBackgroundCheckBox"
+                      mnemonicParsing="false" selected="true" text="%common.background"
+                      GridPane.columnIndex="2" GridPane.rowIndex="5"/>
 
-				<Separator prefWidth="200.0" GridPane.columnIndex="1"
-					GridPane.columnSpan="5" GridPane.rowIndex="6" />
+            <Separator prefWidth="200.0" GridPane.columnIndex="1"
+                       GridPane.columnSpan="5" GridPane.rowIndex="6"/>
 
-				<Glyph fx:id="audioLinkGlyph" fontFamily="FontAwesome" icon="LINK"
-					GridPane.rowIndex="7" />
-				<Label text="%dialog.edit_filenames.audio"
-					GridPane.columnIndex="1" GridPane.rowIndex="7" />
-				<FilenameTextField fx:id="audioField"
-					GridPane.columnIndex="2" GridPane.rowIndex="7" />
-				<Label text="." GridPane.columnIndex="3" GridPane.rowIndex="7" />
-				<ComboBox fx:id="audioExtensionField"
-					GridPane.columnIndex="4" GridPane.rowIndex="7" />
+            <Glyph fx:id="audioLinkGlyph" fontFamily="FontAwesome" icon="LINK"
+                   GridPane.rowIndex="7"/>
+            <Label text="%dialog.edit_filenames.audio"
+                   GridPane.columnIndex="1" GridPane.rowIndex="7"/>
+            <FilenameTextField fx:id="audioField"
+                               GridPane.columnIndex="2" GridPane.rowIndex="7"/>
+            <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="7"/>
+            <ComboBox fx:id="audioExtensionField"
+                      GridPane.columnIndex="4" GridPane.rowIndex="7"/>
 
-				<Glyph fx:id="coverLinkGlyph" fontFamily="FontAwesome" icon="LINK"
-					GridPane.rowIndex="8" />
-				<Label text="%dialog.edit_filenames.cover"
-					GridPane.columnIndex="1" GridPane.rowIndex="8" />
-				<FilenameTextField fx:id="coverField"
-					GridPane.columnIndex="2" GridPane.rowIndex="8" />
-				<Label text="." GridPane.columnIndex="3" GridPane.rowIndex="8" />
-				<TextField fx:id="coverExtensionField"
-					GridPane.columnIndex="4" GridPane.rowIndex="8" />
-				<CheckBox fx:id="addCoCheckBox" mnemonicParsing="false"
-					selected="true" text="[CO]" GridPane.columnIndex="5"
-					GridPane.rowIndex="8" />
+            <Glyph fx:id="coverLinkGlyph" fontFamily="FontAwesome" icon="LINK"
+                   GridPane.rowIndex="8"/>
+            <Label text="%dialog.edit_filenames.cover"
+                   GridPane.columnIndex="1" GridPane.rowIndex="8"/>
+            <FilenameTextField fx:id="coverField"
+                               GridPane.columnIndex="2" GridPane.rowIndex="8"/>
+            <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="8"/>
+            <TextField fx:id="coverExtensionField"
+                       GridPane.columnIndex="4" GridPane.rowIndex="8"/>
+            <CheckBox fx:id="addCoCheckBox" mnemonicParsing="false"
+                      selected="true" text="[CO]" GridPane.columnIndex="5"
+                      GridPane.rowIndex="8"/>
 
-				<Glyph fx:id="videoLinkGlyph" fontFamily="FontAwesome" icon="LINK"
-					GridPane.rowIndex="9" />
-				<Label fx:id="videoLabel" text="%dialog.edit_filenames.video"
-					GridPane.columnIndex="1" GridPane.rowIndex="9" />
-				<FilenameTextField fx:id="videoField"
-					GridPane.columnIndex="2" GridPane.rowIndex="9" />
-				<Label text="." GridPane.columnIndex="3" GridPane.rowIndex="9" />
-				<TextField fx:id="videoExtensionField"
-					GridPane.columnIndex="4" GridPane.rowIndex="9" />
+            <Glyph fx:id="videoLinkGlyph" fontFamily="FontAwesome" icon="LINK"
+                   GridPane.rowIndex="9"/>
+            <Label fx:id="videoLabel" text="%dialog.edit_filenames.video"
+                   GridPane.columnIndex="1" GridPane.rowIndex="9"/>
+            <FilenameTextField fx:id="videoField"
+                               GridPane.columnIndex="2" GridPane.rowIndex="9"/>
+            <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="9"/>
+            <TextField fx:id="videoExtensionField"
+                       GridPane.columnIndex="4" GridPane.rowIndex="9"/>
 
-				<Glyph fx:id="backgroundLinkGlyph" fontFamily="FontAwesome"
-					icon="LINK" GridPane.rowIndex="10" />
-				<Label fx:id="backgroundLabel" text="%dialog.edit_filenames.background"
-					GridPane.columnIndex="1" GridPane.rowIndex="10" />
-				<FilenameTextField fx:id="backgroundField"
-					GridPane.columnIndex="2" GridPane.rowIndex="10" />
-				<Label text="." GridPane.columnIndex="3" GridPane.rowIndex="10" />
-				<TextField fx:id="backgroundExtensionField"
-					GridPane.columnIndex="4" GridPane.rowIndex="10" />
-			</children>
-			<padding>
-				<Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
-			</padding>
-		</ManageableGridPane>
-	</content>
+            <Glyph fx:id="backgroundLinkGlyph" fontFamily="FontAwesome"
+                   icon="LINK" GridPane.rowIndex="10"/>
+            <Label fx:id="backgroundLabel" text="%dialog.edit_filenames.background"
+                   GridPane.columnIndex="1" GridPane.rowIndex="10"/>
+            <FilenameTextField fx:id="backgroundField"
+                               GridPane.columnIndex="2" GridPane.rowIndex="10"/>
+            <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="10"/>
+            <TextField fx:id="backgroundExtensionField"
+                       GridPane.columnIndex="4" GridPane.rowIndex="10"/>
+            <Separator prefWidth="200.0" GridPane.columnIndex="1"
+                       GridPane.columnSpan="5" GridPane.rowIndex="11"/>
+            <Label text="%dialog.edit_filenames.format_ver" GridPane.columnSpan="3"
+                   GridPane.columnIndex="1" GridPane.rowIndex="12"/>
+            <ChoiceBox fx:id="formatSpecificationChoiceBox" minWidth="75" GridPane.columnSpan="2" GridPane.columnIndex="4" GridPane.rowIndex="12" />
+        </ManageableGridPane>
+    </content>
 </fx:root>

--- a/src/main/resources/fxml/EditFilenamesDialogPaneLayout.fxml
+++ b/src/main/resources/fxml/EditFilenamesDialogPaneLayout.fxml
@@ -16,8 +16,8 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import org.controlsfx.glyphfont.Glyph?>
-
 <?import javafx.scene.layout.VBox?>
+
 <fx:root type="javafx.scene.control.DialogPane" xmlns="http://javafx.com/javafx/8.0.60"
          xmlns:fx="http://javafx.com/fxml/1">
     <content>
@@ -33,21 +33,14 @@
                     <ColumnConstraints/>
                 </columnConstraints>
                 <rowConstraints>
-                    <RowConstraints minHeight="10.0" prefHeight="30.0"
-                                    vgrow="NEVER"/>
-                    <RowConstraints minHeight="10.0" prefHeight="30.0"
-                                    vgrow="NEVER"/>
-                    <RowConstraints minHeight="10.0" prefHeight="30.0"
-                                    vgrow="NEVER"/>
-                    <RowConstraints minHeight="10.0" prefHeight="30.0"
-                                    vgrow="NEVER"/>
+                    <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER"/>
+                    <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER"/>
                     <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
                     <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
-                    <RowConstraints minHeight="10.0" prefHeight="30.0"
-                                    vgrow="NEVER"/>
+                    <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER"/>
                 </rowConstraints>
                 <padding>
-                    <Insets left="20.0" right="20.0" top="20.0"/>
+                    <Insets left="20.0" right="20.0" top="10.0"/>
                 </padding>
                 <Label text="%dialog.edit_filenames.artist"
                        GridPane.columnIndex="1"/>
@@ -59,34 +52,21 @@
                 <TextField fx:id="titleField" promptText="%common.title"
                            GridPane.columnIndex="2" GridPane.rowIndex="1"/>
 
-                <Separator prefHeight="5.0" prefWidth="151.0"
-                           GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.rowIndex="2"/>
-
-                <Glyph fx:id="filenameLinkGlyph" fontFamily="FontAwesome"
-                       icon="LINK" GridPane.rowIndex="3"/>
-                <Label text="%dialog.edit_filenames.filename"
-                       GridPane.columnIndex="1" GridPane.rowIndex="3"/>
-                <FilenameTextField fx:id="filenameField"
-                                   GridPane.columnIndex="2" GridPane.rowIndex="3"/>
-
-                <Separator prefHeight="0.0" prefWidth="162.0"
-                           GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.rowIndex="4"/>
+                <Separator prefWidth="162.0" GridPane.columnIndex="0" GridPane.columnSpan="3" GridPane.rowIndex="2"/>
 
                 <Label text="%dialog.edit_filenames.format_ver" GridPane.columnSpan="3" GridPane.columnIndex="1"
-                       GridPane.rowIndex="5"/>
+                       GridPane.rowIndex="3"/>
                 <ChoiceBox fx:id="formatSpecificationChoiceBox" minWidth="75" GridPane.columnSpan="2"
-                           GridPane.columnIndex="3" GridPane.rowIndex="5"/>
+                           GridPane.columnIndex="3" GridPane.rowIndex="3"/>
 
-                <Separator prefWidth="200.0" GridPane.columnIndex="1" GridPane.columnSpan="5" GridPane.rowIndex="6"/>
+                <Separator prefWidth="200.0" GridPane.columnIndex="0" GridPane.columnSpan="3" GridPane.rowIndex="4"/>
             </ManageableGridPane>
-            <ManageableGridPane hgap="10.0">
+            <ManageableGridPane hgap="20.0">
                 <columnConstraints>
-                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0"/>
-                    <ColumnConstraints hgrow="SOMETIMES"/>
-                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0"
-                                       prefWidth="200.0"/>
-                    <ColumnConstraints hgrow="SOMETIMES"/>
-                    <ColumnConstraints hgrow="SOMETIMES" prefWidth="75.0"/>
+                    <ColumnConstraints hgrow="NEVER"/>
+                    <ColumnConstraints hgrow="NEVER"/>
+                    <ColumnConstraints hgrow="NEVER"/>
+                    <ColumnConstraints hgrow="NEVER"/>
                     <ColumnConstraints/>
                 </columnConstraints>
                 <rowConstraints>
@@ -101,6 +81,11 @@
                 <CheckBox fx:id="includeBackgroundCheckBox"
                           mnemonicParsing="false" selected="true" text="%common.background"
                           GridPane.columnIndex="2" />
+                <CheckBox fx:id="includeInstrumentalCheckBox"
+                          mnemonicParsing="false" selected="true" text="%common.instrumental"
+                          GridPane.columnIndex="3"/>
+                <CheckBox fx:id="includeVocalsCheckBox" mnemonicParsing="false"
+                          selected="true" text="%common.vocals" GridPane.columnIndex="4"/>
             </ManageableGridPane>
             <ManageableGridPane fx:id="filenamesGridPane" hgap="10.0">
                 <columnConstraints>
@@ -115,61 +100,96 @@
                 <rowConstraints>
                     <RowConstraints minHeight="10.0" prefHeight="30.0"
                                     vgrow="NEVER"/>
+                    <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
                     <RowConstraints minHeight="10.0" prefHeight="30.0"
                                     vgrow="NEVER"/>
                     <RowConstraints minHeight="10.0" prefHeight="30.0"
                                     vgrow="NEVER"/>
+                    <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                    vgrow="NEVER"/>
+                    <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
+                    <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
                     <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
                     <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
                 </rowConstraints>
                 <padding>
-                    <Insets bottom="20.0" left="20.0" right="20.0" />
+                    <Insets left="20.0" right="20.0" />
                 </padding>
 
-                <Separator prefWidth="200.0" GridPane.columnIndex="1"
-                           GridPane.columnSpan="5" GridPane.rowIndex="0"/>
+                <Separator prefHeight="5.0" prefWidth="151.0"
+                           GridPane.columnIndex="0" GridPane.columnSpan="5" GridPane.rowIndex="0"/>
+
+                <Glyph fx:id="filenameLinkGlyph" fontFamily="FontAwesome"
+                       icon="LINK" GridPane.rowIndex="1"/>
+                <Label text="%dialog.edit_filenames.filename"
+                       GridPane.columnIndex="1" GridPane.rowIndex="1"/>
+                <FilenameTextField fx:id="filenameField"
+                                   GridPane.columnIndex="2" GridPane.rowIndex="1"/>
+
+                <Separator prefWidth="200.0" GridPane.columnIndex="0"
+                           GridPane.columnSpan="5" GridPane.rowIndex="2"/>
 
                 <Glyph fx:id="audioLinkGlyph" fontFamily="FontAwesome" icon="LINK"
-                       GridPane.rowIndex="1"/>
-                <Label text="%dialog.edit_filenames.audio"
-                       GridPane.columnIndex="1" GridPane.rowIndex="1"/>
-                <FilenameTextField fx:id="audioField"
-                                   GridPane.columnIndex="2" GridPane.rowIndex="1"/>
-                <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="1"/>
-                <ComboBox fx:id="audioExtensionField"
-                          GridPane.columnIndex="4" GridPane.rowIndex="1"/>
-
-                <Glyph fx:id="coverLinkGlyph" fontFamily="FontAwesome" icon="LINK"
-                       GridPane.rowIndex="2"/>
-                <Label text="%dialog.edit_filenames.cover"
-                       GridPane.columnIndex="1" GridPane.rowIndex="2"/>
-                <FilenameTextField fx:id="coverField"
-                                   GridPane.columnIndex="2" GridPane.rowIndex="2"/>
-                <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="2"/>
-                <TextField fx:id="coverExtensionField"
-                           GridPane.columnIndex="4" GridPane.rowIndex="2"/>
-                <CheckBox fx:id="addCoCheckBox" mnemonicParsing="false" selected="true" text="[CO]"
-                          GridPane.columnIndex="5" GridPane.rowIndex="2"/>
-
-                <Glyph fx:id="videoLinkGlyph" fontFamily="FontAwesome" icon="LINK"
                        GridPane.rowIndex="3"/>
-                <Label fx:id="videoLabel" text="%dialog.edit_filenames.video"
+                <Label text="%dialog.edit_filenames.audio"
                        GridPane.columnIndex="1" GridPane.rowIndex="3"/>
-                <FilenameTextField fx:id="videoField"
+                <FilenameTextField fx:id="audioField"
                                    GridPane.columnIndex="2" GridPane.rowIndex="3"/>
                 <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="3"/>
-                <TextField fx:id="videoExtensionField"
-                           GridPane.columnIndex="4" GridPane.rowIndex="3"/>
+                <ComboBox fx:id="audioExtensionField"
+                          GridPane.columnIndex="4" GridPane.rowIndex="3"/>
 
-                <Glyph fx:id="backgroundLinkGlyph" fontFamily="FontAwesome"
-                       icon="LINK" GridPane.rowIndex="4"/>
-                <Label fx:id="backgroundLabel" text="%dialog.edit_filenames.background"
+                <Glyph fx:id="coverLinkGlyph" fontFamily="FontAwesome" icon="LINK"
+                       GridPane.rowIndex="4"/>
+                <Label text="%dialog.edit_filenames.cover"
                        GridPane.columnIndex="1" GridPane.rowIndex="4"/>
-                <FilenameTextField fx:id="backgroundField"
+                <FilenameTextField fx:id="coverField"
                                    GridPane.columnIndex="2" GridPane.rowIndex="4"/>
                 <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="4"/>
-                <TextField fx:id="backgroundExtensionField"
+                <TextField fx:id="coverExtensionField"
                            GridPane.columnIndex="4" GridPane.rowIndex="4"/>
+                <CheckBox fx:id="addCoCheckBox" mnemonicParsing="false" selected="true" text="[CO]"
+                          GridPane.columnIndex="5" GridPane.rowIndex="4"/>
+
+                <Glyph fx:id="videoLinkGlyph" fontFamily="FontAwesome" icon="LINK"
+                       GridPane.rowIndex="5"/>
+                <Label fx:id="videoLabel" text="%dialog.edit_filenames.video"
+                       GridPane.columnIndex="1" GridPane.rowIndex="5"/>
+                <FilenameTextField fx:id="videoField"
+                                   GridPane.columnIndex="2" GridPane.rowIndex="5"/>
+                <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="5"/>
+                <TextField fx:id="videoExtensionField"
+                           GridPane.columnIndex="4" GridPane.rowIndex="5"/>
+
+                <Glyph fx:id="backgroundLinkGlyph" fontFamily="FontAwesome"
+                       icon="LINK" GridPane.rowIndex="6"/>
+                <Label fx:id="backgroundLabel" text="%dialog.edit_filenames.background"
+                       GridPane.columnIndex="1" GridPane.rowIndex="6"/>
+                <FilenameTextField fx:id="backgroundField"
+                                   GridPane.columnIndex="2" GridPane.rowIndex="6"/>
+                <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="6"/>
+                <TextField fx:id="backgroundExtensionField"
+                           GridPane.columnIndex="4" GridPane.rowIndex="6"/>
+
+                <Glyph fx:id="instrumentalLinkGlyph" fontFamily="FontAwesome"
+                       icon="LINK" GridPane.rowIndex="7"/>
+                <Label fx:id="instrumentalLabel" text="%dialog.edit_filenames.instrumental"
+                       GridPane.columnIndex="1" GridPane.rowIndex="7"/>
+                <FilenameTextField fx:id="instrumentalField"
+                                   GridPane.columnIndex="2" GridPane.rowIndex="7"/>
+                <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="7"/>
+                <ComboBox fx:id="instrumentalExtensionField"
+                          GridPane.columnIndex="4" GridPane.rowIndex="7"/>
+
+                <Glyph fx:id="vocalsLinkGlyph" fontFamily="FontAwesome"
+                       icon="LINK" GridPane.rowIndex="8"/>
+                <Label fx:id="vocalsLabel" text="%dialog.edit_filenames.vocals"
+                       GridPane.columnIndex="1" GridPane.rowIndex="8"/>
+                <FilenameTextField fx:id="vocalsField"
+                                   GridPane.columnIndex="2" GridPane.rowIndex="8"/>
+                <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="8"/>
+                <ComboBox fx:id="vocalsExtensionField"
+                          GridPane.columnIndex="4" GridPane.rowIndex="8"/>
             </ManageableGridPane>
         </VBox>
     </content>

--- a/src/main/resources/fxml/EditFilenamesDialogPaneLayout.fxml
+++ b/src/main/resources/fxml/EditFilenamesDialogPaneLayout.fxml
@@ -17,127 +17,160 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import org.controlsfx.glyphfont.Glyph?>
 
+<?import javafx.scene.layout.VBox?>
 <fx:root type="javafx.scene.control.DialogPane" xmlns="http://javafx.com/javafx/8.0.60"
          xmlns:fx="http://javafx.com/fxml/1">
     <content>
-        <ManageableGridPane fx:id="gridPane" hgap="10.0">
-            <columnConstraints>
-                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0"/>
-                <ColumnConstraints hgrow="SOMETIMES"/>
-                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0"
-                                   prefWidth="200.0"/>
-                <ColumnConstraints hgrow="SOMETIMES"/>
-                <ColumnConstraints hgrow="SOMETIMES" prefWidth="75.0"/>
-                <ColumnConstraints/>
-            </columnConstraints>
-            <rowConstraints>
-                <RowConstraints minHeight="10.0" prefHeight="30.0"
-                                vgrow="NEVER"/>
-                <RowConstraints minHeight="10.0" prefHeight="30.0"
-                                vgrow="NEVER"/>
-                <RowConstraints minHeight="10.0" prefHeight="30.0"
-                                vgrow="NEVER"/>
-                <RowConstraints minHeight="10.0" prefHeight="30.0"
-                                vgrow="NEVER"/>
-                <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
-                <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
-                <RowConstraints minHeight="10.0" prefHeight="30.0"
-                                vgrow="NEVER"/>
-                <RowConstraints minHeight="10.0" prefHeight="30.0"
-                                vgrow="NEVER"/>
-                <RowConstraints minHeight="10.0" prefHeight="30.0"
-                                vgrow="NEVER"/>
-                <RowConstraints minHeight="10.0" prefHeight="30.0"
-                                vgrow="NEVER"/>
-                <RowConstraints minHeight="10.0" prefHeight="30.0"
-                                vgrow="NEVER"/>
-                <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
-                <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
-            </rowConstraints>
-            <padding>
-                <Insets bottom="20.0" left="20.0" right="20.0" top="20.0"/>
-            </padding>
-            <Label text="%dialog.edit_filenames.artist"
-                   GridPane.columnIndex="1"/>
-            <TextField fx:id="artistField" promptText="%common.artist"
-                       GridPane.columnIndex="2"/>
+        <VBox>
+            <ManageableGridPane fx:id="artistTitleGridPane" hgap="10.0">
+                <columnConstraints>
+                    <ColumnConstraints hgrow="NEVER" minWidth="10.0"/>
+                    <ColumnConstraints hgrow="SOMETIMES" minWidth="50.0"/>
+                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0"
+                                       prefWidth="200.0"/>
+                    <ColumnConstraints hgrow="SOMETIMES"/>
+                    <ColumnConstraints hgrow="SOMETIMES" prefWidth="75.0"/>
+                    <ColumnConstraints/>
+                </columnConstraints>
+                <rowConstraints>
+                    <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                    vgrow="NEVER"/>
+                    <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                    vgrow="NEVER"/>
+                    <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                    vgrow="NEVER"/>
+                    <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                    vgrow="NEVER"/>
+                    <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
+                    <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
+                    <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                    vgrow="NEVER"/>
+                </rowConstraints>
+                <padding>
+                    <Insets left="20.0" right="20.0" top="20.0"/>
+                </padding>
+                <Label text="%dialog.edit_filenames.artist"
+                       GridPane.columnIndex="1"/>
+                <TextField fx:id="artistField" promptText="%common.artist"
+                           GridPane.columnIndex="2"/>
 
-            <Label text="%dialog.edit_filenames.title"
-                   GridPane.columnIndex="1" GridPane.rowIndex="1"/>
-            <TextField fx:id="titleField" promptText="%common.title"
-                       GridPane.columnIndex="2" GridPane.rowIndex="1"/>
+                <Label text="%dialog.edit_filenames.title"
+                       GridPane.columnIndex="1" GridPane.rowIndex="1"/>
+                <TextField fx:id="titleField" promptText="%common.title"
+                           GridPane.columnIndex="2" GridPane.rowIndex="1"/>
 
-            <Separator prefHeight="5.0" prefWidth="151.0"
-                       GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.rowIndex="2"/>
+                <Separator prefHeight="5.0" prefWidth="151.0"
+                           GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.rowIndex="2"/>
 
-            <Glyph fx:id="filenameLinkGlyph" fontFamily="FontAwesome"
-                   icon="LINK" GridPane.rowIndex="3"/>
-            <Label text="%dialog.edit_filenames.filename"
-                   GridPane.columnIndex="1" GridPane.rowIndex="3"/>
-            <FilenameTextField fx:id="filenameField"
-                               GridPane.columnIndex="2" GridPane.rowIndex="3"/>
+                <Glyph fx:id="filenameLinkGlyph" fontFamily="FontAwesome"
+                       icon="LINK" GridPane.rowIndex="3"/>
+                <Label text="%dialog.edit_filenames.filename"
+                       GridPane.columnIndex="1" GridPane.rowIndex="3"/>
+                <FilenameTextField fx:id="filenameField"
+                                   GridPane.columnIndex="2" GridPane.rowIndex="3"/>
 
-            <Separator prefHeight="0.0" prefWidth="162.0"
-                       GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.rowIndex="4"/>
+                <Separator prefHeight="0.0" prefWidth="162.0"
+                           GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.rowIndex="4"/>
 
-            <Label text="%dialog.edit_filenames.format_ver" GridPane.columnSpan="3" GridPane.columnIndex="1"
-                   GridPane.rowIndex="5"/>
-            <ChoiceBox fx:id="formatSpecificationChoiceBox" minWidth="75" GridPane.columnSpan="2"
-                       GridPane.columnIndex="4" GridPane.rowIndex="5"/>
+                <Label text="%dialog.edit_filenames.format_ver" GridPane.columnSpan="3" GridPane.columnIndex="1"
+                       GridPane.rowIndex="5"/>
+                <ChoiceBox fx:id="formatSpecificationChoiceBox" minWidth="75" GridPane.columnSpan="2"
+                           GridPane.columnIndex="3" GridPane.rowIndex="5"/>
 
-            <Separator prefWidth="200.0" GridPane.columnIndex="1" GridPane.columnSpan="5" GridPane.rowIndex="6"/>
+                <Separator prefWidth="200.0" GridPane.columnIndex="1" GridPane.columnSpan="5" GridPane.rowIndex="6"/>
+            </ManageableGridPane>
+            <ManageableGridPane hgap="10.0">
+                <columnConstraints>
+                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0"/>
+                    <ColumnConstraints hgrow="SOMETIMES"/>
+                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0"
+                                       prefWidth="200.0"/>
+                    <ColumnConstraints hgrow="SOMETIMES"/>
+                    <ColumnConstraints hgrow="SOMETIMES" prefWidth="75.0"/>
+                    <ColumnConstraints/>
+                </columnConstraints>
+                <rowConstraints>
+                    <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                    vgrow="NEVER"/>
+                </rowConstraints>
+                <padding>
+                    <Insets left="20.0" right="20.0" />
+                </padding>
+                <CheckBox fx:id="includeVideoCheckBox" mnemonicParsing="false"
+                          selected="true" text="%common.video" GridPane.columnIndex="1"/>
+                <CheckBox fx:id="includeBackgroundCheckBox"
+                          mnemonicParsing="false" selected="true" text="%common.background"
+                          GridPane.columnIndex="2" />
+            </ManageableGridPane>
+            <ManageableGridPane fx:id="filenamesGridPane" hgap="10.0">
+                <columnConstraints>
+                    <ColumnConstraints hgrow="NEVER" minWidth="10.0"/>
+                    <ColumnConstraints hgrow="SOMETIMES" minWidth="50.0"/>
+                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0"
+                                       prefWidth="200.0"/>
+                    <ColumnConstraints hgrow="SOMETIMES"/>
+                    <ColumnConstraints hgrow="SOMETIMES" prefWidth="75.0"/>
+                    <ColumnConstraints/>
+                </columnConstraints>
+                <rowConstraints>
+                    <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                    vgrow="NEVER"/>
+                    <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                    vgrow="NEVER"/>
+                    <RowConstraints minHeight="10.0" prefHeight="30.0"
+                                    vgrow="NEVER"/>
+                    <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
+                    <RowConstraints prefHeight="30.0" vgrow="NEVER"/>
+                </rowConstraints>
+                <padding>
+                    <Insets bottom="20.0" left="20.0" right="20.0" />
+                </padding>
 
-            <CheckBox fx:id="includeVideoCheckBox" mnemonicParsing="false"
-                      selected="true" text="%common.video" GridPane.columnIndex="1"
-                      GridPane.rowIndex="7"/>
-            <CheckBox fx:id="includeBackgroundCheckBox"
-                      mnemonicParsing="false" selected="true" text="%common.background"
-                      GridPane.columnIndex="2" GridPane.rowIndex="7"/>
+                <Separator prefWidth="200.0" GridPane.columnIndex="1"
+                           GridPane.columnSpan="5" GridPane.rowIndex="0"/>
 
-            <Separator prefWidth="200.0" GridPane.columnIndex="1"
-                       GridPane.columnSpan="5" GridPane.rowIndex="8"/>
+                <Glyph fx:id="audioLinkGlyph" fontFamily="FontAwesome" icon="LINK"
+                       GridPane.rowIndex="1"/>
+                <Label text="%dialog.edit_filenames.audio"
+                       GridPane.columnIndex="1" GridPane.rowIndex="1"/>
+                <FilenameTextField fx:id="audioField"
+                                   GridPane.columnIndex="2" GridPane.rowIndex="1"/>
+                <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="1"/>
+                <ComboBox fx:id="audioExtensionField"
+                          GridPane.columnIndex="4" GridPane.rowIndex="1"/>
 
-            <Glyph fx:id="audioLinkGlyph" fontFamily="FontAwesome" icon="LINK"
-                   GridPane.rowIndex="9"/>
-            <Label text="%dialog.edit_filenames.audio"
-                   GridPane.columnIndex="1" GridPane.rowIndex="9"/>
-            <FilenameTextField fx:id="audioField"
-                               GridPane.columnIndex="2" GridPane.rowIndex="9"/>
-            <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="9"/>
-            <ComboBox fx:id="audioExtensionField"
-                      GridPane.columnIndex="4" GridPane.rowIndex="9"/>
+                <Glyph fx:id="coverLinkGlyph" fontFamily="FontAwesome" icon="LINK"
+                       GridPane.rowIndex="2"/>
+                <Label text="%dialog.edit_filenames.cover"
+                       GridPane.columnIndex="1" GridPane.rowIndex="2"/>
+                <FilenameTextField fx:id="coverField"
+                                   GridPane.columnIndex="2" GridPane.rowIndex="2"/>
+                <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="2"/>
+                <TextField fx:id="coverExtensionField"
+                           GridPane.columnIndex="4" GridPane.rowIndex="2"/>
+                <CheckBox fx:id="addCoCheckBox" mnemonicParsing="false" selected="true" text="[CO]"
+                          GridPane.columnIndex="5" GridPane.rowIndex="2"/>
 
-            <Glyph fx:id="coverLinkGlyph" fontFamily="FontAwesome" icon="LINK"
-                   GridPane.rowIndex="10"/>
-            <Label text="%dialog.edit_filenames.cover"
-                   GridPane.columnIndex="1" GridPane.rowIndex="10"/>
-            <FilenameTextField fx:id="coverField"
-                               GridPane.columnIndex="2" GridPane.rowIndex="10"/>
-            <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="10"/>
-            <TextField fx:id="coverExtensionField"
-                       GridPane.columnIndex="4" GridPane.rowIndex="10"/>
-            <CheckBox fx:id="addCoCheckBox" mnemonicParsing="false" selected="true" text="[CO]"
-                      GridPane.columnIndex="5" GridPane.rowIndex="10"/>
+                <Glyph fx:id="videoLinkGlyph" fontFamily="FontAwesome" icon="LINK"
+                       GridPane.rowIndex="3"/>
+                <Label fx:id="videoLabel" text="%dialog.edit_filenames.video"
+                       GridPane.columnIndex="1" GridPane.rowIndex="3"/>
+                <FilenameTextField fx:id="videoField"
+                                   GridPane.columnIndex="2" GridPane.rowIndex="3"/>
+                <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="3"/>
+                <TextField fx:id="videoExtensionField"
+                           GridPane.columnIndex="4" GridPane.rowIndex="3"/>
 
-            <Glyph fx:id="videoLinkGlyph" fontFamily="FontAwesome" icon="LINK"
-                   GridPane.rowIndex="11"/>
-            <Label fx:id="videoLabel" text="%dialog.edit_filenames.video"
-                   GridPane.columnIndex="1" GridPane.rowIndex="11"/>
-            <FilenameTextField fx:id="videoField"
-                               GridPane.columnIndex="2" GridPane.rowIndex="11"/>
-            <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="11"/>
-            <TextField fx:id="videoExtensionField"
-                       GridPane.columnIndex="4" GridPane.rowIndex="11"/>
-
-            <Glyph fx:id="backgroundLinkGlyph" fontFamily="FontAwesome"
-                   icon="LINK" GridPane.rowIndex="12"/>
-            <Label fx:id="backgroundLabel" text="%dialog.edit_filenames.background"
-                   GridPane.columnIndex="1" GridPane.rowIndex="12"/>
-            <FilenameTextField fx:id="backgroundField"
-                               GridPane.columnIndex="2" GridPane.rowIndex="12"/>
-            <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="12"/>
-            <TextField fx:id="backgroundExtensionField"
-                       GridPane.columnIndex="4" GridPane.rowIndex="12"/>
-        </ManageableGridPane>
+                <Glyph fx:id="backgroundLinkGlyph" fontFamily="FontAwesome"
+                       icon="LINK" GridPane.rowIndex="4"/>
+                <Label fx:id="backgroundLabel" text="%dialog.edit_filenames.background"
+                       GridPane.columnIndex="1" GridPane.rowIndex="4"/>
+                <FilenameTextField fx:id="backgroundField"
+                                   GridPane.columnIndex="2" GridPane.rowIndex="4"/>
+                <Label text="." GridPane.columnIndex="3" GridPane.rowIndex="4"/>
+                <TextField fx:id="backgroundExtensionField"
+                           GridPane.columnIndex="4" GridPane.rowIndex="4"/>
+            </ManageableGridPane>
+        </VBox>
     </content>
 </fx:root>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -184,9 +184,12 @@ dialog.edit_filenames.title=Title:
 dialog.edit_filenames.filename=Filename:
 dialog.edit_filenames.video=Video:
 dialog.edit_filenames.background=Background:
+dialog.edit_filenames.instrumental=Instrumental:
+dialog.edit_filenames.vocals=Vocals:
 dialog.edit_filenames.format_ver=UltraStar format specification version:
 dialog.edit_filenames.audio=Audio:
 dialog.edit_filenames.cover=Cover:
+dialog.edit_filenames.no_format=None
 
 dialog.edit_medley.title=Edit Medley
 dialog.edit_medley.header=Please enter new values
@@ -392,6 +395,8 @@ common.tag_value=Value
 common.new=New
 common.video=Video
 common.background=Background
+common.instrumental=Instrumental
+common.vocals=Vocals
 
 filechooser.txt_files=*.txt (txt files)
 filechooser.audio_files=Supported audio files

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -184,6 +184,7 @@ dialog.edit_filenames.title=Title:
 dialog.edit_filenames.filename=Filename:
 dialog.edit_filenames.video=Video:
 dialog.edit_filenames.background=Background:
+dialog.edit_filenames.format_ver=UltraStar format specification version:
 dialog.edit_filenames.audio=Audio:
 dialog.edit_filenames.cover=Cover:
 

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -184,9 +184,12 @@ dialog.edit_filenames.title=Title:
 dialog.edit_filenames.filename=Filename:
 dialog.edit_filenames.video=Video:
 dialog.edit_filenames.background=Background:
+dialog.edit_filenames.instrumental=Instrumental:
+dialog.edit_filenames.vocals=Vocals:
 dialog.edit_filenames.format_ver=UltraStar format specification version:
 dialog.edit_filenames.audio=Audio:
 dialog.edit_filenames.cover=Cover:
+dialog.edit_filenames.no_format=None
 
 dialog.edit_medley.title=Edit Medley
 dialog.edit_medley.header=Please enter new values
@@ -392,6 +395,8 @@ common.tag_value=Value
 common.new=New
 common.video=Video
 common.background=Background
+common.instrumental=Instrumental
+common.vocals=Vocals
 
 filechooser.txt_files=*.txt (txt files)
 filechooser.audio_files=Supported audio files

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -184,6 +184,7 @@ dialog.edit_filenames.title=Title:
 dialog.edit_filenames.filename=Filename:
 dialog.edit_filenames.video=Video:
 dialog.edit_filenames.background=Background:
+dialog.edit_filenames.format_ver=UltraStar format specification version:
 dialog.edit_filenames.audio=Audio:
 dialog.edit_filenames.cover=Cover:
 

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -184,6 +184,7 @@ dialog.edit_filenames.title=Tytu\u0142:
 dialog.edit_filenames.filename=Nazwa pliku:
 dialog.edit_filenames.video=Wideo:
 dialog.edit_filenames.background=T\u0142o:
+dialog.edit_filenames.format_ver=Wersja specyfikacji formatu UltraStar:
 dialog.edit_filenames.audio=Audio:
 dialog.edit_filenames.cover=Ok\u0142adka:
 

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -184,9 +184,12 @@ dialog.edit_filenames.title=Tytu\u0142:
 dialog.edit_filenames.filename=Nazwa pliku:
 dialog.edit_filenames.video=Wideo:
 dialog.edit_filenames.background=T\u0142o:
+dialog.edit_filenames.instrumental=Podk\u0142ad:
+dialog.edit_filenames.vocals=Wokal:
 dialog.edit_filenames.format_ver=Wersja specyfikacji formatu UltraStar:
 dialog.edit_filenames.audio=Audio:
 dialog.edit_filenames.cover=Ok\u0142adka:
+dialog.edit_filenames.no_format=Brak
 
 dialog.edit_medley.title=Edytuj Medley
 dialog.edit_medley.header=Prosz\u0119 podaj nowe warto\u015Bci
@@ -400,6 +403,8 @@ common.tag_value=Warto\u015B\u0107
 common.new=Nowy
 common.video=Wideo
 common.background=T\u0142o
+common.instrumental=Podk\u0142ad
+common.vocals=Wokal
 
 filechooser.txt_files=*.txt (pliki txt)
 filechooser.audio_files=Obs\u0142ugiwane pliki audio


### PR DESCRIPTION
New Song Wizard's filename dialog changes:
 * added select for UltraStar specification format version (default is NONE, but last used value is remembered)
 * added possibility to define VOCALS & INSTRUMENTAL files (blocked if chosen format is 1.0.0 as it does not support these tags)
 *  if format 1.0.0 or 1.1.0 is chosen, audio filename is saved both in MP3 and AUDIO tags (only MP3 otherwise)

Rename files dialog changes:
* added possibility to edit VOCALS & INSTRUMENTAL filenames
* if song's UltraStar specification format version forbids VOCALS & INSTRUMENTAL tags, their edition is disabled
* after audio file rename, MP3 tag is always updated, AUDIO tag if already present or required by current format version

