### PR TITLE
Fix/audio tag unsupported in format 1.0.0

### DIFF
--- a/src/main/java/com/github/nianna/karedi/context/actions/NewSongWizard.java
+++ b/src/main/java/com/github/nianna/karedi/context/actions/NewSongWizard.java
@@ -54,6 +54,7 @@ class NewSongWizard {
 			song.setTagValue(TagKey.ARTIST, result.getArtist());
 			song.setTagValue(TagKey.TITLE, result.getTitle());
 			song.formatSpecificationVersion()
+					.filter(format -> format.supports(TagKey.AUDIO))
 					.ifPresent(ignored -> song.setTagValue(TagKey.AUDIO, result.getAudioFilename()));
 			song.setTagValue(TagKey.MP3, result.getAudioFilename());
 			song.setTagValue(TagKey.COVER, result.getCoverFilename());

--- a/src/main/java/com/github/nianna/karedi/context/actions/RenameAction.java
+++ b/src/main/java/com/github/nianna/karedi/context/actions/RenameAction.java
@@ -54,7 +54,7 @@ class RenameAction extends ContextfulKarediAction {
                         result.getArtist()));
                 addSubCommand(new ChangeTagValueCommand(song, TagKey.TITLE, result.getTitle()));
                 addSubCommand(new ChangeTagValueCommand(song, TagKey.MP3, result.getAudioFilename()));
-                if (song.hasTag(TagKey.AUDIO) || song.formatSpecificationVersion().isPresent()) {
+                if (song.hasTag(TagKey.AUDIO) || formatSupportsAudio(song)) {
                     addSubCommand(new ChangeTagValueCommand(song, TagKey.AUDIO, result.getAudioFilename()));
                 }
                 addSubCommand(new ChangeTagValueCommand(song, TagKey.COVER, result.getCoverFilename()));
@@ -74,6 +74,12 @@ class RenameAction extends ContextfulKarediAction {
                         .ifPresent(filename -> addSubCommand(new ChangeTagValueCommand(song, TagKey.VOCALS, filename)));
             }
         };
+    }
+
+    private static boolean formatSupportsAudio(Song song) {
+        return song.formatSpecificationVersion()
+                .filter(format -> format.supports(TagKey.AUDIO))
+                .isPresent();
     }
 
 }

--- a/src/main/java/com/github/nianna/karedi/song/Song.java
+++ b/src/main/java/com/github/nianna/karedi/song/Song.java
@@ -76,7 +76,11 @@ public class Song implements IntBounded, Problematic {
 	}
 
 	public Optional<String> getMainAudioTagValue() {
-		return getTagValue(TagKey.AUDIO).or(() -> getTagValue(TagKey.MP3));
+		TagKey mainAudioTagKey = formatSpecificationVersion()
+				.filter(format -> format.supports(TagKey.AUDIO))
+				.map(ignored -> TagKey.AUDIO)
+				.orElse(TagKey.MP3);
+		return getTagValue(mainAudioTagKey);
 	}
 
 	public Optional<String> getTagValue(String key) {

--- a/src/main/java/com/github/nianna/karedi/song/tag/FormatSpecification.java
+++ b/src/main/java/com/github/nianna/karedi/song/tag/FormatSpecification.java
@@ -21,8 +21,12 @@ public enum FormatSpecification {
 
     public boolean supports(String tagKey) {
         return TagKey.optionalValueOf(tagKey)
-                .filter(recognizedKey -> FormatSpecificationSupportedTags.isSupported(this, recognizedKey))
+                .filter(this::supports)
                 .isPresent();
+    }
+
+    public boolean supports(TagKey tagKey) {
+        return FormatSpecificationSupportedTags.isSupported(this, tagKey);
     }
 
     @Override

--- a/src/main/java/com/github/nianna/karedi/song/tag/FormatSpecification.java
+++ b/src/main/java/com/github/nianna/karedi/song/tag/FormatSpecification.java
@@ -19,6 +19,11 @@ public enum FormatSpecification {
                 .findFirst();
     }
 
+    public boolean supports(String tagKey) {
+        return TagKey.optionalValueOf(tagKey)
+                .filter(recognizedKey -> FormatSpecificationSupportedTags.isSupported(this, recognizedKey))
+                .isPresent();
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/com/github/nianna/karedi/song/tag/FormatSpecificationSupportedTags.java
+++ b/src/main/java/com/github/nianna/karedi/song/tag/FormatSpecificationSupportedTags.java
@@ -1,0 +1,53 @@
+package com.github.nianna.karedi.song.tag;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+class FormatSpecificationSupportedTags {
+
+    private static final List<TagKey> V_1_0_0_SUPPORTED_KEYS = List.of(
+            TagKey.VERSION,
+            TagKey.TITLE,
+            TagKey.ARTIST,
+            TagKey.MP3,
+            TagKey.BPM,
+            TagKey.GAP,
+            TagKey.COVER,
+            TagKey.BACKGROUND,
+            TagKey.VIDEO,
+            TagKey.VIDEOGAP,
+            TagKey.GENRE,
+            TagKey.EDITION,
+            TagKey.CREATOR,
+            TagKey.LANGUAGE,
+            TagKey.YEAR,
+            TagKey.START,
+            TagKey.END,
+            TagKey.PREVIEWSTART,
+            TagKey.MEDLEYSTARTBEAT,
+            TagKey.MEDLEYENDBEAT,
+            TagKey.CALCMEDLEY,
+            TagKey.P1,
+            TagKey.P2,
+            TagKey.COMMENT
+    );
+
+    private static final List<TagKey> V_1_1_0_SUPPORTED_KEYS = Stream.concat(
+            V_1_0_0_SUPPORTED_KEYS.stream(),
+            Stream.of(TagKey.AUDIO, TagKey.VOCALS, TagKey.INSTRUMENTAL, TagKey.TAGS, TagKey.PROVIDEDBY)
+    ).toList();
+
+    private static final Map<FormatSpecification, List<TagKey>> SUPPORTED_KEYS = Map.of(
+            FormatSpecification.V_1_0_0, V_1_0_0_SUPPORTED_KEYS,
+            FormatSpecification.V_1_1_0, V_1_1_0_SUPPORTED_KEYS
+    );
+
+    private FormatSpecificationSupportedTags() {
+
+    }
+
+    static boolean isSupported(FormatSpecification formatSpecification, TagKey tagKey) {
+        return SUPPORTED_KEYS.get(formatSpecification).contains(tagKey);
+    }
+}

--- a/src/main/java/com/github/nianna/karedi/song/tag/TagKeyValidator.java
+++ b/src/main/java/com/github/nianna/karedi/song/tag/TagKeyValidator.java
@@ -3,65 +3,21 @@ package com.github.nianna.karedi.song.tag;
 import com.github.nianna.karedi.problem.TagProblem;
 import com.github.nianna.karedi.problem.UnsupportedTagProblem;
 
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 public abstract class TagKeyValidator {
-
-    private static final List<TagKey> V_1_0_0_SUPPORTED_KEYS = List.of(
-            TagKey.VERSION,
-            TagKey.TITLE,
-            TagKey.ARTIST,
-            TagKey.MP3,
-            TagKey.BPM,
-            TagKey.GAP,
-            TagKey.COVER,
-            TagKey.BACKGROUND,
-            TagKey.VIDEO,
-            TagKey.VIDEOGAP,
-            TagKey.GENRE,
-            TagKey.EDITION,
-            TagKey.CREATOR,
-            TagKey.LANGUAGE,
-            TagKey.YEAR,
-            TagKey.START,
-            TagKey.END,
-            TagKey.PREVIEWSTART,
-            TagKey.MEDLEYSTARTBEAT,
-            TagKey.MEDLEYENDBEAT,
-            TagKey.CALCMEDLEY,
-            TagKey.P1,
-            TagKey.P2,
-            TagKey.COMMENT
-    );
-
-    private static final List<TagKey> V_1_1_0_SUPPORTED_KEYS = Stream.concat(
-            V_1_0_0_SUPPORTED_KEYS.stream(),
-            Stream.of(TagKey.AUDIO, TagKey.VOCALS, TagKey.INSTRUMENTAL, TagKey.TAGS, TagKey.PROVIDEDBY)
-    ).toList();
-
-    private static final Map<FormatSpecification, List<TagKey>> SUPPORTED_KEYS = Map.of(
-            FormatSpecification.V_1_0_0, V_1_0_0_SUPPORTED_KEYS,
-            FormatSpecification.V_1_1_0, V_1_1_0_SUPPORTED_KEYS
-    );
 
     private TagKeyValidator() {
 
     }
 
-    public static Optional<TagProblem> validate(String tag, FormatSpecification formatSpecification) {
-        if (SUPPORTED_KEYS.get(formatSpecification) == null) {
+    public static Optional<TagProblem> validate(String tagKey, FormatSpecification formatSpecification) {
+        if (formatSpecification == null) {
             return Optional.empty();
         }
 
-        boolean isKeySupported = TagKey.optionalValueOf(tag)
-                .map(SUPPORTED_KEYS.get(formatSpecification)::contains)
-                .orElse(false);
-
-        if (!isKeySupported) {
-            return Optional.of(new UnsupportedTagProblem(tag));
+        if (!formatSpecification.supports(tagKey)) {
+            return Optional.of(new UnsupportedTagProblem(tagKey));
         }
         return Optional.empty();
     }


### PR DESCRIPTION
Adjusted logic to use just MP3 tag in format version 1.0.0 since AUDIO is supported only from version 1.1.0 onwards.