### PR TITLE
Use floor function for millis to beat conversion

### DIFF
--- a/src/main/java/com/github/nianna/karedi/util/BeatMillisConverter.java
+++ b/src/main/java/com/github/nianna/karedi/util/BeatMillisConverter.java
@@ -21,8 +21,11 @@ public class BeatMillisConverter implements Observable {
 	}
 
 	public int millisToBeat(long millis) {
-		Long beat = Math.round((millis - gap) / beatDuration);
-		return beat.intValue();
+		int beatCandidate = (int) Math.floor((millis - gap) / beatDuration);
+		if (beatToMillis(beatCandidate + 1) <= millis) {
+			return beatCandidate + 1;
+		}
+		return beatCandidate;
 	}
 
 	public double getBeatDuration() {

--- a/src/test/java/com/github/nianna/karedi/util/BeatMillisConverterTest.java
+++ b/src/test/java/com/github/nianna/karedi/util/BeatMillisConverterTest.java
@@ -43,4 +43,11 @@ public class BeatMillisConverterTest {
 		assertEquals(1, converter.millisToBeat(millis));
 	}
 
+	@Test
+	public void conversionMethodsAreConsistent() {
+		converter = new BeatMillisConverter(440, 223.94);
+		int testBeat = 255;
+		assertEquals(testBeat, converter.millisToBeat(converter.beatToMillis(testBeat)));
+	}
+
 }


### PR DESCRIPTION
Millis to beat conversion is used by lyrics displayer to find appropriate note to highlight its lyrics based on the current playback time.
By using _round_ method, the beats in fact started half beat earlier in the playback time than they should have - syllables were highlighted too soon.

Using floor method fixes this issue but a workaround is necessary, because sometimes _millisToBeat(beatToMillis(beat)) != beat_ due to rounding.