### PR TITLE
Fix scroll for zero deltaX and deltaY events and improve secondary (horizontal) scroll wheel support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>Karedi</groupId>
 	<artifactId>Karedi</artifactId>
-	<version>1.6.0</version>
+	<version>1.6.0-scroll</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>Karedi</groupId>
 	<artifactId>Karedi</artifactId>
-	<version>1.6.0-scroll</version>
+	<version>1.6.0</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
<h1>Scrolling issues fixes and improvements </h1>
<h2>HI_RES scroll problem</h2>
Fixes #85 

<h2> Improvements </h2>
A code redesign was needed to sensibly handle different combinations of modifier keys and two axes of scrolling. The committed functions are documented in the code itself, but here is a summary of the proposed scrolling functionality:

<h3> ⌨ Ctrl pressed <=> zooming in/out </h3>
<h4> ↕ Scrolled by standard, physically vertical scroll wheel on the mouse </h4>
<table>
  <tr>
    <td> <b> ⌨ Shift </b> </td> <td> <b> ⌨ Alt </b> </td> <td> <b> Zoom </b> </td>
  </tr>
  <tr>
    <td> - </td> <td> - </td> <td> ↔️↕️ both directions </td>
  </tr>
  <tr>
    <td> Shift </td> <td> - </td> <td> ↔️ horizontally </td>
  </tr>
  <tr>
    <td> - </td> <td> Alt </td> <td> ↕️ vertically </td>
  </tr>
  <tr>
    <td> Shift </td> <td> Alt </td> <td> - </td>
  </tr>
</table>
<h4> ↔ Scrolled by additional, physically horizontal scroll wheel on the mouse </h4>
<table>
  <tr>
    <td> <b> ⌨ Shift </b> </td> <td> <b> ⌨ Alt </b> </td> <td> <b> Zoom </b> </td>
  </tr>
  <tr>
    <td> - </td> <td> - </td> <td> ↔️ horizontally </td>
  </tr>
  <tr>
    <td> Shift </td> <td> - </td> <td> - </td>
  </tr>
  <tr>
    <td> - </td> <td> Alt </td> <td> ↕️ vertically </td>
  </tr>
  <tr>
    <td> Shift </td> <td> Alt </td> <td> - </td>
  </tr>
</table>
<h3> ↔ Scrolled by additional, physically horizontal scroll wheel on the mouse <br/>
OR (⌨ Shift AND ↕ Scrolled by standard, physically vertical scroll wheel on the mouse) </h3>
<table>
  <tr>
    <td> <b> ⌨ Alt </b> </td> <td> <b> Scroll </b> </td>
  </tr>
  <tr>
    <td> - </td> <td> ↔️ horizontally, beat by beat </td>
  </tr>
  <tr>
    <td> Alt </td> <td> ↔️ horizontally, beat by beat, 10x faster </td>
  </tr>
</table>
<h3> ↕ Scrolled by standard, physically vertical scroll wheel on the mouse <br/>
OR (⌨ Shift AND ↔ Scrolled by additional, physically horizontal scroll wheel on the mouse) </h3>
<table>
  <tr>
    <td> <b> ⌨ Alt </b> </td> <td> <b> Scroll </b> </td>
  </tr>
  <tr>
    <td> - </td> <td> ↔️ horizontally, by whole line </td>
  </tr>
  <tr>
    <td> Alt </td> <td> ↕️ vertically </td>
  </tr>
</table>