### PR TITLE
Apply styling to alerts and dialogs

### DIFF
--- a/src/main/java/com/github/nianna/karedi/KarediApp.java
+++ b/src/main/java/com/github/nianna/karedi/KarediApp.java
@@ -160,6 +160,10 @@ public class KarediApp extends Application {
 		return primaryStage.getScene().getStylesheets().contains(NIGHT_MODE_CSS_STYLESHEET);
 	}
 
+	public List<String> getActiveStylesheets() {
+		return primaryStage.getScene().getStylesheets().stream().toList();
+	}
+
 	public boolean saveChangesIfUserWantsTo() {
 		if (appContext.getTxtContext().needsSaving()) {
 			Alert alert = new SaveChangesAlert(getFileName(appContext.getTxtContext().getActiveFile()));

--- a/src/main/java/com/github/nianna/karedi/controller/AudioManagerController.java
+++ b/src/main/java/com/github/nianna/karedi/controller/AudioManagerController.java
@@ -7,6 +7,7 @@ import com.github.nianna.karedi.context.ActionContext;
 import com.github.nianna.karedi.context.AppContext;
 import com.github.nianna.karedi.context.AudioContext;
 import com.github.nianna.karedi.control.SliderTableCell;
+import com.github.nianna.karedi.dialog.StyleableAlert;
 import com.github.nianna.karedi.util.ContextMenuBuilder;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.DoubleProperty;
@@ -116,7 +117,7 @@ public class AudioManagerController implements Controller {
 	private void confirmAndRemoveSelected() {
 		if (!table.getSelectionModel().isEmpty()) {
 			PreloadedAudioFile file = table.getSelectionModel().getSelectedItem();
-			Alert alert = new Alert(AlertType.CONFIRMATION);
+			Alert alert = new StyleableAlert(AlertType.CONFIRMATION);
 			alert.setTitle(I18N.get("dialog.delete_audio.title"));
 			alert.setHeaderText(I18N.get("dialog.delete_audio.header"));
 			alert.setContentText(file.getName());

--- a/src/main/java/com/github/nianna/karedi/dialog/CheckListViewDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/CheckListViewDialog.java
@@ -11,11 +11,10 @@ import javafx.scene.Node;
 import javafx.scene.control.ButtonBar.ButtonData;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.CheckBox;
-import javafx.scene.control.Dialog;
 import javafx.scene.control.Label;
 import com.github.nianna.karedi.control.ManageableGridPane;
 
-public class CheckListViewDialog<T> extends Dialog<List<T>> {
+public class CheckListViewDialog<T> extends StyleableDialog<List<T>> {
 	private ManageableGridPane grid = new ManageableGridPane();
 	private Function<T, String> stringConverter;
 	private Optional<Integer> upperLimit = Optional.empty();

--- a/src/main/java/com/github/nianna/karedi/dialog/ConvertFormatDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/ConvertFormatDialog.java
@@ -5,7 +5,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ButtonType;
-import javafx.scene.control.Dialog;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
@@ -18,7 +17,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-public class ConvertFormatDialog extends Dialog<ButtonType> {
+public class ConvertFormatDialog extends StyleableDialog<ButtonType> {
 
 	private final List<TagRepresentation> allTags;
 	private final List<TagRepresentation> tagsToBeRemoved;

--- a/src/main/java/com/github/nianna/karedi/dialog/EditBpmDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/EditBpmDialog.java
@@ -1,8 +1,8 @@
 package com.github.nianna.karedi.dialog;
 
+import com.github.nianna.karedi.I18N;
 import javafx.scene.control.ButtonBar.ButtonData;
 import javafx.scene.control.ButtonType;
-import com.github.nianna.karedi.I18N;
 
 public class EditBpmDialog extends ModifyBpmDialog {
 

--- a/src/main/java/com/github/nianna/karedi/dialog/EditTagDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/EditTagDialog.java
@@ -12,7 +12,6 @@ import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.control.ButtonType;
-import javafx.scene.control.Dialog;
 import javafx.scene.control.TextField;
 import org.controlsfx.control.textfield.AutoCompletionBinding;
 import org.controlsfx.validation.ValidationResult;
@@ -23,7 +22,7 @@ import org.controlsfx.validation.decoration.ValidationDecoration;
 import java.util.Arrays;
 import java.util.List;
 
-public class EditTagDialog extends Dialog<Tag> {
+public class EditTagDialog extends StyleableDialog<Tag> {
 	@FXML
 	private TextField keyField;
 	@FXML

--- a/src/main/java/com/github/nianna/karedi/dialog/ExportWithErrorsAlert.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/ExportWithErrorsAlert.java
@@ -1,9 +1,8 @@
 package com.github.nianna.karedi.dialog;
 
-import javafx.scene.control.Alert;
 import com.github.nianna.karedi.I18N;
 
-public class ExportWithErrorsAlert extends Alert {
+public class ExportWithErrorsAlert extends StyleableAlert {
 
 	public ExportWithErrorsAlert() {
 		super(AlertType.CONFIRMATION);

--- a/src/main/java/com/github/nianna/karedi/dialog/OverwriteAlert.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/OverwriteAlert.java
@@ -1,11 +1,10 @@
 package com.github.nianna.karedi.dialog;
 
-import java.io.File;
-
-import javafx.scene.control.Alert;
 import com.github.nianna.karedi.I18N;
 
-public class OverwriteAlert extends Alert {
+import java.io.File;
+
+public class OverwriteAlert extends StyleableAlert {
 
 	public OverwriteAlert(File file) {
 		super(AlertType.CONFIRMATION);

--- a/src/main/java/com/github/nianna/karedi/dialog/PreferencesDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/PreferencesDialog.java
@@ -10,7 +10,6 @@ import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ChoiceBox;
-import javafx.scene.control.Dialog;
 import javafx.scene.control.TextField;
 import javafx.util.StringConverter;
 
@@ -18,7 +17,7 @@ import java.io.File;
 import java.util.Locale;
 import java.util.Optional;
 
-public class PreferencesDialog extends Dialog<PreferencesResult> {
+public class PreferencesDialog extends StyleableDialog<PreferencesResult> {
 
 	@FXML
 	private ChoiceBox<Locale> languageSelect;

--- a/src/main/java/com/github/nianna/karedi/dialog/SaveChangesAlert.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/SaveChangesAlert.java
@@ -1,10 +1,9 @@
 package com.github.nianna.karedi.dialog;
 
-import javafx.scene.control.Alert;
-import javafx.scene.control.ButtonType;
 import com.github.nianna.karedi.I18N;
+import javafx.scene.control.ButtonType;
 
-public class SaveChangesAlert extends Alert {
+public class SaveChangesAlert extends StyleableAlert {
 	public static final ButtonType SAVE_BUTTON = new ButtonType(I18N.get("common.save"));
 	public static final ButtonType DISCARD_BUTTON = new ButtonType(I18N.get("common.not_save"));
 

--- a/src/main/java/com/github/nianna/karedi/dialog/SkippableDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/SkippableDialog.java
@@ -1,13 +1,12 @@
 package com.github.nianna.karedi.dialog;
 
-import java.util.Optional;
-
+import com.github.nianna.karedi.I18N;
 import javafx.scene.control.ButtonBar.ButtonData;
 import javafx.scene.control.ButtonType;
-import javafx.scene.control.Dialog;
-import com.github.nianna.karedi.I18N;
 
-public abstract class SkippableDialog<T> extends Dialog<Optional<T>> {
+import java.util.Optional;
+
+public abstract class SkippableDialog<T> extends StyleableDialog<Optional<T>> {
 	protected static final ButtonType SKIP_TYPE = new ButtonType(I18N.get("common.skip"), ButtonData.NEXT_FORWARD);
 
 	public SkippableDialog() {

--- a/src/main/java/com/github/nianna/karedi/dialog/StyleableAlert.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/StyleableAlert.java
@@ -1,0 +1,13 @@
+package com.github.nianna.karedi.dialog;
+
+
+import com.github.nianna.karedi.KarediApp;
+import javafx.scene.control.Alert;
+
+public class StyleableAlert extends Alert {
+
+    public StyleableAlert(AlertType alertType) {
+        super(alertType);
+        getDialogPane().getStylesheets().addAll(KarediApp.getInstance().getActiveStylesheets());
+    }
+}

--- a/src/main/java/com/github/nianna/karedi/dialog/StyleableDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/StyleableDialog.java
@@ -1,0 +1,12 @@
+package com.github.nianna.karedi.dialog;
+
+
+import com.github.nianna.karedi.KarediApp;
+import javafx.scene.control.Dialog;
+
+public class StyleableDialog<T> extends Dialog<T> {
+
+    public StyleableDialog() {
+        getDialogPane().getStylesheets().addAll(KarediApp.getInstance().getActiveStylesheets());
+    }
+}

--- a/src/main/java/com/github/nianna/karedi/dialog/ValidatedDialog.java
+++ b/src/main/java/com/github/nianna/karedi/dialog/ValidatedDialog.java
@@ -1,13 +1,11 @@
 package com.github.nianna.karedi.dialog;
 
-import org.controlsfx.validation.ValidationSupport;
-
 import javafx.collections.transformation.FilteredList;
 import javafx.scene.control.ButtonBar.ButtonData;
 import javafx.scene.control.ButtonType;
-import javafx.scene.control.Dialog;
+import org.controlsfx.validation.ValidationSupport;
 
-public abstract class ValidatedDialog<T> extends Dialog<T> {
+public abstract class ValidatedDialog<T> extends StyleableDialog<T> {
 	protected ValidationSupport validationSupport;
 
 	public ValidatedDialog() {


### PR DESCRIPTION
Switching the view mode updates stylesheets of the application's primary stage. This change however is not automatically propagated to alerts and dialogs since they are in fact separate stages. In order to have consistent styling, the currently active custom stylesheets need to be applied to them every time they are being created.

FileChooser's look is handled by the operating system so it is not possible to style them.
