### PR TITLE
Add flac audio format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Karedi uses the following libraries:
 * [hyphenator](https://github.com/Nianna/hyphenator) for syllabification,
 * [javasound-aac](https://github.com/Tianscar/javasound-aac) for m4a files support,
 * mp3spi for mp3 files support,
-* [java-vorbis-support](https://github.com/Trilarion/java-vorbis-support) for Ogg Vorbis support.
+* [java-vorbis-support](https://github.com/Trilarion/java-vorbis-support) for Ogg Vorbis support,
+* [vavi-sound-flac-nayuki](https://github.com/umjammer/vavi-sound-flac-nayuki?tab=GPL-3.0-1-ov-file) for flac files support.
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 		<junit.version>5.11.0</junit.version>
 		<richtextfx.version>0.11.0</richtextfx.version>
 		<hyphenator.version>1.0.1</hyphenator.version>
+		<vavi-sound-flac-nayuki.version>0.0.2</vavi-sound-flac-nayuki.version>
 	</properties>
 
 	<build>
@@ -417,6 +418,10 @@
 
 	<repositories>
 		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
+		<repository>
 			<id>repo</id>
 			<url>file:///${project.basedir}/lib</url>
 		</repository>
@@ -521,6 +526,12 @@
 			<groupId>org.openjfx</groupId>
 			<artifactId>javafx-fxml</artifactId>
 			<version>${javafx.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.umjammer</groupId>
+			<artifactId>vavi-sound-flac-nayuki</artifactId>
+			<version>${vavi-sound-flac-nayuki.version}</version>
 		</dependency>
 
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 		<richtextfx.version>0.11.0</richtextfx.version>
 		<hyphenator.version>1.0.1</hyphenator.version>
 		<vavi-sound-flac-nayuki.version>0.0.2</vavi-sound-flac-nayuki.version>
+		<vavi-commons.version>1.1.12</vavi-commons.version>
 	</properties>
 
 	<build>
@@ -301,6 +302,43 @@
                                 </module>
 								<module>
 									<artifact>
+										<groupId>com.github.umjammer.vavi-commons</groupId>
+										<artifactId>vavi-commons</artifactId>
+										<version>${vavi-commons.version}</version>
+									</artifact>
+									<moduleInfoSource>
+										module vavi.commons {
+											requires java.logging;
+											requires java.desktop;
+
+											exports vavi.util;
+											exports vavi.io;
+										}
+									</moduleInfoSource>
+								</module>
+								<module>
+									<artifact>
+										<groupId>com.github.umjammer</groupId>
+										<artifactId>vavi-sound-flac-nayuki</artifactId>
+										<version>${vavi-sound-flac-nayuki.version}</version>
+									</artifact>
+									<moduleInfoSource>
+										module vavi.sound.flac.nayuki {
+											requires java.desktop;
+											requires java.logging;
+											requires vavi.commons;
+
+											exports vavi.sound.sampled.flac.nayuki.spi;
+
+											provides javax.sound.sampled.spi.AudioFileReader
+												with vavi.sound.sampled.flac.nayuki.spi.FlacAudioFileReader;
+											provides javax.sound.sampled.spi.FormatConversionProvider
+												with vavi.sound.sampled.flac.nayuki.spi.FlacFormatConversionProvider;
+										}
+									</moduleInfoSource>
+								</module>
+								<module>
+									<artifact>
 										<groupId>org.fxmisc.flowless</groupId>
 										<artifactId>flowless</artifactId>
 										<version>0.7.0</version>
@@ -418,12 +456,12 @@
 
 	<repositories>
 		<repository>
-			<id>jitpack.io</id>
-			<url>https://jitpack.io</url>
-		</repository>
-		<repository>
 			<id>repo</id>
 			<url>file:///${project.basedir}/lib</url>
+		</repository>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
 		</repository>
 	</repositories>
 

--- a/src/main/java/com/github/nianna/karedi/audio/AudioFileLoader.java
+++ b/src/main/java/com/github/nianna/karedi/audio/AudioFileLoader.java
@@ -16,7 +16,8 @@ public class AudioFileLoader {
 	private static final List<String> WAV_EXT = List.of("wav");
 	private static final List<String> AAC_EXT = List.of("m4a", "mp4", "aac");
 	private static final List<String> VORBIS_EXT = List.of("ogg");
-	private static final List<String> SUPPORTED_EXTENSIONS = Stream.of(MP3_EXT, WAV_EXT, AAC_EXT, VORBIS_EXT)
+	private static final List<String> FLAC_EXT = List.of("flac");
+	private static final List<String> SUPPORTED_EXTENSIONS = Stream.of(MP3_EXT, WAV_EXT, AAC_EXT, VORBIS_EXT, FLAC_EXT)
 			.flatMap(Collection::stream)
 			.toList();
 
@@ -67,6 +68,9 @@ public class AudioFileLoader {
 			}
 			if (VORBIS_EXT.contains(extension)) {
 				return SourceDataLineAudioFile.vorbisFile(file);
+			}
+			if (FLAC_EXT.contains(extension)) {
+				return SourceDataLineAudioFile.flacFile(file);
 			}
 			if (SUPPORTED_EXTENSIONS.contains(extension)) {
 				return SourceDataLineAudioFile.aacFile(file);

--- a/src/main/java/com/github/nianna/karedi/audio/SourceDataLineAudioFile.java
+++ b/src/main/java/com/github/nianna/karedi/audio/SourceDataLineAudioFile.java
@@ -91,6 +91,16 @@ class SourceDataLineAudioFile extends PreloadedAudioFile {
         }
     }
 
+
+    public static PreloadedAudioFile flacFile(File file) {
+        try {
+            AudioInputStream in = AudioSystem.getAudioInputStream(file);
+            return convertAndLoadAudio(file, in);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private static SourceDataLineAudioFile convertAndLoadAudio(File file, AudioInputStream in)
             throws LineUnavailableException, IOException {
         AudioFormat convertedFormat = in.getFormat();

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -13,6 +13,7 @@ module karedi {
     requires com.github.trilarion.sound;
     requires nianna.hyphenator;
     requires mp3spi;
+    requires vavi.sound.flac.nayuki;
 
     opens com.github.nianna.karedi to javafx.graphics;
     opens com.github.nianna.karedi.controller to javafx.fxml;


### PR DESCRIPTION
I don't know if it's allowed to use other repositories like jitpack.io in this project, and I don't fully understand the caching that happens in GH actions and the Maven configuration, but I found and tested this SPI provider library: [https://github.com/umjammer/vavi-sound-flac-nayuki](https://github.com/umjammer/vavi-sound-flac-nayuki) under the GPL-3.0 license. It works seamlessly when I tested on a few flac files

<img src="https://github.com/user-attachments/assets/6c819518-29d3-4e4f-8d48-e7f739e6b8b9" width="500px">