### PR TITLE
Fix scroll for zero deltaX and deltaY events - cont.

### DIFF
--- a/src/main/java/com/github/nianna/karedi/control/ScrollableSlider.java
+++ b/src/main/java/com/github/nianna/karedi/control/ScrollableSlider.java
@@ -8,7 +8,7 @@ public class ScrollableSlider extends Slider {
 		setOnScroll(event -> {
 			if (event.getDeltaY() > 0) {
 				increment();
-			} else {
+			} else if (event.getDeltaY() < 0) {
 				decrement();
 			}
 		});

--- a/src/main/java/com/github/nianna/karedi/controller/ToolbarController.java
+++ b/src/main/java/com/github/nianna/karedi/controller/ToolbarController.java
@@ -122,7 +122,7 @@ public class ToolbarController implements Controller {
 		playbackSpeedSpinner.setOnScroll(event -> {
 			if (event.getDeltaY() > 0) {
 				playbackSpeedSpinner.increment();
-			} else {
+			} else if (event.getDeltaY() < 0) {
 				playbackSpeedSpinner.decrement();
 			}
 		});

--- a/src/main/java/com/github/nianna/karedi/util/NumericNodeUtils.java
+++ b/src/main/java/com/github/nianna/karedi/util/NumericNodeUtils.java
@@ -18,6 +18,13 @@ public final class NumericNodeUtils {
 			Supplier<Optional<? extends Number>> supplier, Consumer<Double> consumer,
 			double basicStep) {
 		return (event -> {
+			// Catch for unexpected events, that might happen when javafx.graphics native-glass handles GTK's events.
+			// Fix for HI_RES scroll on Linux, GTK. Maybe even more.
+			if (event.getDeltaY() == 0 && event.getDeltaX() == 0) {
+				event.consume();
+				return;
+			}
+
 			boolean wheelDown = event.getDeltaY() < 0 || event.getDeltaX() < 0;
 
 			supplier.get().ifPresent(oldValue -> {


### PR DESCRIPTION
Fixes #85 

Fixed scrolling bugs in:
- tags table
- playback speed spinner
- track volume sliders

Follow-up to PR #86, which fixed bugs in:
- editor controller

If I'm not mistaken, these are all the places where ScrollEvents are consumed - please let me know if I forgot something 😇